### PR TITLE
Update Core.lua to reflect changes to ElitismHelper skill list and spiteful melee support

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -399,6 +399,11 @@ DE.AurasNoTank = {
 
 }
 
+DE.Swings = {
+	[161917] = 20,		-- DEBUG
+	[174773] = 20,		-- Spiteful Shade
+}
+
 -- Public APIs
 
 function Engine:GetRecord(combatID, playerGUID)
@@ -487,6 +492,31 @@ function DE:SpellDamage(timestamp, eventType, srcGUID, srcName, srcFlags, dstGUI
 end
 
 function DE:SwingDamage(timestamp, eventType, srcGUID, srcName, srcFlags, dstGUID, dstName, dstFlags, aAmount)
+	local unitGUID = dstGUID 
+	local meleeSpellId = 260421
+	
+	if (DE.Swings[DE:srcGUIDtoID(srcGUID)] and UnitIsPlayer(dstName)) then
+		if not self.db[self.current] then self.db[self.current] = {} end
+        if not self.db[self.current][unitGUID] then self.db[self.current][unitGUID] = {
+            sum = 0,
+            cnt = 0,
+            spells = {},
+            auras = {},
+            auracnt = 0
+        } end
+		if not self.db[self.current][unitGUID].spells then
+            self.db[self.current][unitGUID].spells = {}
+        end
+		if not self.db[self.current][unitGUID].spells[meleeSpellId] then self.db[self.current][unitGUID].spells[meleeSpellId] = {
+            cnt = 0,
+            sum = 0
+        } end
+		
+		self.db[self.current][unitGUID].sum = self.db[self.current][unitGUID].sum + aAmount
+        self.db[self.current][unitGUID].cnt = self.db[self.current][unitGUID].cnt + 1
+        self.db[self.current][unitGUID].spells[meleeSpellId].sum = self.db[self.current][unitGUID].spells[meleeSpellId].sum + aAmount
+        self.db[self.current][unitGUID].spells[meleeSpellId].cnt = self.db[self.current][unitGUID].spells[meleeSpellId].cnt + 1
+	end
 end
 
 function DE:AuraApply(timestamp, eventType, srcGUID, srcName, srcFlags, dstGUID, dstName, dstFlags, spellId, spellName, spellSchool, auraType, auraAmount)
@@ -717,4 +747,13 @@ function DE:OnInitialize()
 
 
     self:SecureHook(Details, 'StartMeUp', 'LoadHooks')
+end
+
+function DE:srcGUIDtoID(srcGUID)
+    local sep = "-"
+    local t={}
+    for str in string.gmatch(srcGUID, "([^"..sep.."]+)") do
+            table.insert(t, str)
+    end
+    return tonumber(t[#t-1])
 end

--- a/Core.lua
+++ b/Core.lua
@@ -199,283 +199,204 @@ DE.CustomDisplayAuras = {
 
 DE.Spells = {
 	-- Debug
+	--[] = 20,      --  ()
 	--[252144] = 1,
 	--[252150] = 1,
-
-  -- Reaping
-	--[290085] = 20,          -- Expel Soul (Environment)
-	[296142] = 20,          -- Shadow Smash (Lost Soul)
-	-- [288693] = 20,          -- Grave Bolt (Tormented Soul) Is this really avoidable?
 	
 	-- Affixes
 	[209862] = 20,		-- Volcanic Plume (Environment)
 	[226512] = 20,		-- Sanguine Ichor (Environment)
-
-	-- Freehold
-	[272046] = 20,		--- Dive Bomb (Sharkbait)
-	[257426] = 20,		--- Brutal Backhand (Irontide Enforcer)
-	[258352] = 20,		--- Grapeshot (Captain Eudora)
-	[256594] = 20,		--- Barrel Smash (Captain Raoul)
-	[272374] = 20,		--- Whirlpool of Blades (Captain Jolly)
-	[256546] = 20,		--- Shark Tornado (Trothak)
-	[257310] = 20,		--- Cannon Barrage (Harlan Sweete)
-	[257784] = 20,		--- Frost Blast (Bilge Rat Brinescale)
-	[257902] = 20,		--- Shell Bounce (Ludwig Von Tortollan)
-	[258199] = 20,		--- Ground Shatter (Irontide Crusher)
-	[276061] = 20,		--- Boulder Throw (Irontide Crusher)
-	[258779] = 20,		--- Sea Spout (Irontide Oarsman)
-	[274400] = 20,		--- Duelist Dash (Cutwater Duelist)
-	[257274] = 20,		--- Vile Coating (Environment)
-	[258673] = 20,		--- Azerite Grenade (Irontide Crackshot)
-	[274389] = 20,		--- Rat Traps (Vermin Trapper)
-	[257460] = 20,		--- Fiery Debris (Harlan Sweete)
-	--[257871] = 20,		--- Blade Barrage (Irontide Buccaneer)
-	--[257757] = 20,		--- Goin' Bananas (Bilge Rat Buccaneer)
+	[240448] = 20,      -- Quaking (Environment)
+	[343520] = 20,      -- Storming (Environment)
+	[342494] = 20, 		-- Belligerent Boast(Season 1 Pridefull)
 	
-	-- Shrine of the Storm
-	[276268] = 20,		--- Heaving Blow (Shrine Templar)
-	[267973] = 20,		--- Wash Away (Temple Attendant)
-	[268059] = 20,		--- Anchor of Binding (Tidesage Spiritualist)
-	[264155] = 20,		--- Surging Rush (Aqu'sirr)
-	[267841] = 20,		--- Blowback (Galecaller Faye)
-	[267899] = 20,		--- Hindering Cleave (Brother Ironhull)
-	[268280] = 20,		--- Tidal Pod (Tidesage Enforcer)
-	[276286] = 20,		--- Slicing Hurricane (Galecaller Apprentice)
-	[276292] = 20,		--- Whirlign Slam (Ironhull Apprentice)
-	[267385] = 20,		--- Tentacle Slam (Vol'zith the Whisperer)
+	-- Mists of Tirna Scythe
+	[321968] = 20, 		-- Bewildering Pollen (tirnenn Villager)
+	[323137] = 20, 		-- Bewildering Pollen (tirnenn Villager)
+	[323250] = 20,      -- Anima Puddle (Droman Oulfarran)
+	[325027] = 20,      -- Bramble Burst (Drust Boughbreaker)
+	[326022] = 20,      -- Acid Globule (Spinemaw Gorger)
+	[340300] = 20,		-- Tongue Lashing (Mistveil Gorgegullet)
+	[340304] = 20,		-- Poisonous Secretions (Mistveil Gorgegullet)
+	[331743] = 20,		-- Bucking Rampage (Mistveil Guardian)
+	--id ? [340160] = 20,		-- Radiant Breath (Mistveil Matriarch)
 	
-	-- Siege of Boralus
-	[256627] = 20,		--- Slobber Knocker (Kul Tiran Halberd)
-	[256663] = 20,		--- Burning Tar (Blacktar Bomber)
-	[275775] = 20,		--- Savage Tempest (Irontide Raider)
-	[257292] = 20,		--- Heavy Slash (Kul Tiran Vanguard)
-	[272426] = 20,		--- Sighted Artillery (Ashvane Spotter)
-	[257069] = 20,		--- Watertight Shell (Kul Tiran Wavetender)
-	[273681] = 20,		--- Heavy Hitter (Chopper Redhook)
-	[272874] = 20,		--- Trample (Ashvane Commander)
-	[268260] = 20,		--- Broadside (Ashvane Cannoneer)
-	[269029] = 20,		--- Clear the Deck (Dread Captain Lockwood)
-	[268443] = 20,		--- Dread Volley (Dread Captain Lockwood)
-	[272713] = 20,		--- Crushing Slam (Bilge Rat Demolisher)
-	[274941] = 20,		--- Banana Rampage swirlies(Bilge Rat Buccaneer)
-	[257883] = 20,		--- Break Water (Hadal Darkfathom)
-	[276068] = 20,		--- Tidal Surge (Hadal Darkfathom)
-	[257886] = 20,		--- Brine Pool (Hadal Darkfathom)
-	[261565] = 20,		--- Crashing Tide (Hadal Darkfathom)
-	[277535] = 20,		--- Viq'Goth's Wrath (Viq'Goth)
+	--id ? [323177] = 20,		-- Tears of the Forest(Ingra Maloch)
+	[321834] = 20,      -- Dodge Ball (Mistcaller)
+	[336759] = 20,      -- Dodge Ball (Mistcaller)
+	[322655] = 20,		-- Acid Expulsion (Tred'Ova)
+	--id ? [322450] = 20,		-- Consumption (Tred'Ova)
 	
-	-- Tol Dagor
-	[257119] = 20,		--- Sand Trap (The Sand Queen)
-	[257785] = 20,		--- Flashing Daggers (Jes Howlis)
-	[256976] = 20,		--- Ignition (Knight Captain Valyri)
-	[256955] = 20,		--- Cinderflame (Knight Captain Valyri)
-	[256083] = 20,		--- Cross Ignition (Overseer Korgus)
-	[263345] = 20,		--- Massive Blast (Overseer Korgus)
-	[258364] = 20,		--- Fuselighter (Ashvane Flamecaster)
-	[259711] = 20,		--- Lockdown (Ashvane Warden)
-	[256710] = 20,		--- Burning Arsenal (Knight Captain Valyri)
-	
-	-- Waycrest Manor
-	[264531] = 20,		--- Shrapnel Trap (Maddened Survivalist)
-	[264476] = 20,		--- Tracking Explosive (Crazed Marksman)
-	[260569] = 20,		--- Wildfire (Soulbound Goliath)
-	[265407] = 20,		--- Dinner Bell (Banquet Steward)
-	[264923] = 20,		--- Tenderize (Raal the Gluttonous)
-	[264712] = 20,		--- Rotten Expulsion (Raal the Gluttonous)
-	[272669] = 20,		--- Burning Fists (Soulbound Goliath)
-	[278849] = 20,		--- Uproot (Coven Thornshaper)
-	[264040] = 20,		--- Uprooted Thorns (Coven Thornshaper)
-	[265757] = 20,		--- Splinter Spike (Matron Bryndle)
-	[264150] = 20,		--- Shatter (Thornguard)
-	[268387] = 20,		--- Contagious Remnants (Lord Waycrest)
-	[268308] = 20,		--- Discordant Cadenza (Lady Waycrest
-
-	-- Atal'Dazar
-	[253666] = 20,		--- Fiery Bolt (Dazar'ai Juggernaught)
-	[257692] = 20,		--- Tiki Blaze (Environment)
-	[255620] = 20,		--- Festering Eruption (Reanimated Honor Guard)
-	[258723] = 20,		--- Grotesque Pool (Renaimated Honor Guard)
-	[250259] = 20,		--- Toxic Leap (Vol'kaal)
-	[250022] = 20,		--- Echoes of Shadra (Yazma)
-	[250585] = 20, 		--- Toxic Pool (Vol'kaal)
-	[250036] = 20,		--- Shadowy Remains (Echoes of Shadra)
-	[255567] = 20,		--- Frenzied Charge (T'lonja)
-
-	-- King's Rest
-	[270003] = 20,		--- Suppression Slam (Animated Guardian)
-	[269932] = 20,		--- Ghust Slash (Shadow-Borne Warrior)
-	[265781] = 20,		--- Serpentine Gust (The Golden Serpent)
-	[265914] = 20,		--- Molten Gold (The Golden Serpent)
-	[270928] = 20,		--- Bladestorm (King Timalji)
-	[270931] = 20,		--- Darkshot (Queen Patlaa)
-	[270891] = 20,		--- Channel Lightning (King Rahu'ai)
-	[266191] = 20,		--- Whirling Axe (Council of Tribes)
-	[270292] = 20,		--- Purifying Flame (Purification Construct)
-	[270503] = 20,		--- Hunting Leap (Honored Raptor)
-	[270514] = 20,		--- Ground Crush (Spectral Brute)
-	[271564] = 20,		--- Embalming Fluid (Embalming Fluid)
-	[270485] = 20,		--- Blooded Leap (Spectral Berserker)
-	[267639] = 20,		--- Burn Corruption (Mchimba the Embalmer)
-	[268419] = 20,		--- Gale Slash (King Dazar)
-	[268796] = 20,		--- Impaling Spear (King Dazar)
-	
-	-- The MOTHERLODE!!
-	[257371] = 20,		--- Gas Can (Mechanized Peace Keeper)
-	[262287] = 20,		--- Concussion Charge (Mech Jockey / Venture Co. Skyscorcher)
-	[268365] = 20,		--- Mining Charge (Wanton Sapper)
-	[269313] = 20,		--- Final Blast (Wanton Sapper)
-	[275907] = 20,		--- Tectonic Smash (Azerokk)
-	[259533] = 20,		--- Azerite Catalyst (Rixxa Fluxflame)
-	[260103] = 20,		--- Propellant Blast (Rixxa Fluxflame)
-	[260279] = 20,		--- Gattling Gun (Mogul Razdunk)
-	[276234] = 20, 		--- Micro Missiles (Mogul Razdunk)
-	[270277] = 20,		--- Big Red Rocket (Mogul Razdunk)
-	[271432] = 20,		--- Test Missile (Venture Co. War Machine)
-	--[262348] = 20,		--- Mine Blast (Crawler Mine)
-	[257337] = 20,		--- Shocking Claw (Coin-Operated Pummeler)
-	[268417] = 20,		--- Power Through (Azerite Extractor)
-	[268704] = 20,		--- Furious Quake (Stonefury)
-	[258628] = 20,		--- Resonant Quake (Earthrager)
-	[269092] = 20,		--- Artillery Barrage (Ordnance Specialist)
-	[271583] = 20,		--- Black Powder Special (Mines near the track)
-	[269831] = 20,		--- Toxic Sludge (Oil Environment)
-
-	-- Temple of Sethraliss
-	[263425] = 20,		--- Arc Dash (Adderis)
-	[268851] = 20,		--- Lightning Shield (Aspix and Adderis)
-	[263573] = 20,		--- Cyclone Strike (Adderis)
-	[273225] = 20,		--- Volley (Sandswept Marksman)
-	[272655] = 20,		--- Scouring Sand (Mature Krolusk)
-	[273995] = 20,		--- Pyrrhic Blast (Crazed Incubator)
-	[272696] = 20,		--- Lightning in a Bottle (Crazed Incubator)
-	[264206] = 20,		--- Burrow (Merektha)
-	[272657] = 20,		--- Noxious Breath (Merektha)
-	[272821] = 20,		--- Call Lightning (Imbued Stormcaller)
-	[264763] = 20,		--- Spark (Static-charged Dervish)
-	[279014] = 20,		--- Cardiac Shock (Avatar, Environment)
-	
-	-- Underrot
-	[265542] = 20,		--- Rotten Bile (Fetid Maggot)
-	[265019] = 20,		--- Savage Cleave (Chosen Blood Matron)
-	[261498] = 20,		--- Creeping Rot (Elder Leaxa)
-	[264757] = 20,		--- Sanguine Feast (Elder Leaxa)
-	[265665] = 20,		--- Foul Sludge (Living Rot)
-	[260312] = 20,		--- Charge (Cragmaw the Infested)
-	[265511] = 20,		--- Spirit Drain (Spirit Drain Totem)
-	[259720] = 20,		--- Upheaval (Sporecaller Zancha)
-	[270108] = 20,		--- Rotting Spore (Unbound Abomination)
-	[272609] = 20,		--- Maddenin Gaze (Faceless Corruptor)
-	[272469] = 20,		--- Abyssal Slam (Faceless Corruptor)
-	[270108] = 20,		--- Rotting Spore (Unbound Abomination)
-	
-	-- Mechagon Workshop
-	[294128] = 20,		--- Rocket Barrage (Rocket Tonk)
-	[285020] = 20,		--- Whirling Edge (The Platinum Pummeler)
-	[294291] = 20,		--- Process Waste ()
-	[291930] = 20,		--- Air Drop (K.U-J.0)
-	[294324] = 20,		--- Mega Drill (Waste Processing Unit)
-	[293861] = 20,		--- Anti-Personnel Squirrel (Anti-Personnel Squirrel)
-	[295168] = 20,		--- Capacitor Discharge (Blastatron X-80)
-	[294954] = 20,		--- Self-Trimming Hedge (Head Machinist Sparkflux)
+	-- De Other Side
+	[334051] = 20,		-- Erupting Darkness (Death Speaker)
+	[328729] = 20,		-- Dark Lotus (Risen Cultist)
+	[333250] = 20,		-- Reaver (Risen Warlord)
+	[342869] = 20,		-- Enraged Mask (Enraged Spirit)
+	[333790] = 20,		-- Enraged Mask (Enraged Spirit)
+	[332672] = 20,      -- Bladestorm (Atal'ai Deathwalker)
+	[323118] = 20,      -- Blood Barrage (Hakkar the Soulflayer)
+	[331933] = 20,		-- Haywire (Defunct Dental Drill)
+	[332157] = 20,      -- Spinning Up (Headless Client)
+	[323569] = 20,   	-- Spilled Essence (Environement)
+	[320830] = 20,		-- Mechanical Bomb Squirrel
+	[323136] = 20,      -- Anima Starstorm (Runestag Elderhorn)
+	[323992] = 20,      -- Echo Finger Laser X-treme (Millificent Manastorm)
+			
+	[320723] = 20,		-- Displaced Blastwave (Dealer Xy'exa)
+	[334913] = 20,		-- Master of Death (Mueh'zala)
+	[327427] = 20,		-- Shattered Dominion (Mueh'zala)
+	[325691] = 20,      -- Cosmic Collapse (Mueh'zala)
+	[335000] = 20,		-- Stellar cloud (Mueh'zala)
 	
 	
-	-- Mechagon Junkyard
-	[300816] = 20,		--- Slimewave (Slime Elemental)
-	[300188] = 20,		--- Scrap Cannon (Weaponized Crawler)
-	[300427] = 20,		--- Shockwave (Scrapbone Bully)
-	[294890] = 20,		--- Gryro-Scrap (Malfunctioning Scrapbot)
-	[300129] = 20,		--- Self-Destruct Protocol (Malfunctioning Scrapbot)
-	[300561] = 20,		--- Explosion (Scrapbone Trashtosser)
-	[299475] = 20,		--- B.O.R.K. (Scraphound)
-	[299535] = 20,		--- Scrap Blast (Pistonhead Blaster)
-	[298940] = 20,		--- Bolt Buster (Naeno Megacrash)
-	[297283] = 20,		--- Cave In (King Gobbamak)
+	-- Spires of Ascension
+	[331251] = 20,      -- Deep Connection (Azules / Kin-Tara)
+	[317626] = 20,      -- Maw-Touched Venom (Azules)
+	[323786] = 20,      -- Swift Slice (Kyrian Dark-Praetor)
+	[324662] = 20,      -- Ionized Plasma (Multiple) Can this be avoided?
+	[317943] = 20,      -- Sweeping Blow (Frostsworn Vanguard)
+	[324608] = 20,      -- Charged Stomp (Oryphrion)
+	[323740] = 20,		-- Impact (Forsworn Squad-Leader)
+	[336447] = 20,		-- Crashing Strike (Forsworn Squad-Leader)
+	[336444] = 20,		-- Crescendo (Forsworn Helion)
+	[328466] = 20,		-- Charged Spear (Lakesis / Klotos)
+	[336420] = 20,		-- Diminuendo (Klotos / Lakesis)
+	
+	[321034] = 20,      -- Charged Spear (Kin-Tara)
+	[324370] = 20,		-- Attenuated Barrage (Kin-Tara)
+	[324141] = 20,      -- Dark Bolt (Ventunax)
+	[324154] = 20,		-- Dark Stride (Venturax)
+	[323943] = 20,      -- Run Through (Devos)
+	[334625] = 20,		-- Seed of the Abyss (Devos)
 	
 	
-	--- Awakened Lieutenant
-	[314309] = 20,		--- Dark Fury (Urg'roth, Breaker of Heroes)
-	[314467] = 20,		--- Volatile Rupture (Voidweaver Mal'thir)
-	[314565] = 20,		--- Defiled Ground (Blood of the Corruptor)
+	-- The Necrotic Wakes
+	[324391] = 20,		-- Frigid Spikes (Skeletal Monstrosity)
+	-- id ?[324372] = 20,		-- Reaping Winds (Skeletal Monstrosity)
+	-- id ?[320574] = 20,		-- Shadow Well (Zolramus Sorcerer)
+	[333477] = 20,		-- Gut Slice (Goregrind)
+	
+	-- id ?[320637] = 20, 		-- Fetid Gas (Blightbone)
+	[333489] = 20,		-- Necrotic Breath (Amarth)
+	[333492] = 20,		-- Necrotic Ichor (Amarth apply by Necrotic Breath)
+	[320365] = 20,		-- Embalming Ichor (Surgeon Stitchflesh)
+	[320366] = 20,		-- Embalming Ichor (Surgeon Stitchflesh)
+	[327952] = 20,		-- Meat Hook (Stitchflesh)
+	[327100] = 20,      -- Noxious Fog (Stitchflesh)
+	[328212] = 20,      -- Razorshard Ice (Nalthor the Rimebender)
+	[320784] = 20,		-- Comet Storm (Nalthor the Rimebinder)
+	
+	-- Plaguefall
+	[320072] = 20, 		-- Toxic Pool (Decaying Flesh Giant)
+	-- id ?[335882] = 20, 		-- Clinging Infestation (Fen Hatchling)
+	[330404] = 20,		-- Wing Buffet (Plagueroc)
+	-- id ?[320040] = 20,		-- Plagued Carrion (Decaying Flesh Giant)
+	[320072] = 20,		-- Toxic pool (Decaying Flesh Giant)
+	[318949] = 20,      -- Festering Belch (Blighted Spinebreaker)
+	-- id ?[320576] = 20,      -- Obliterating Ooze (Virulax Blightweaver)
+	[319120] = 20, 		-- Putrid Bile (Gushing Slime)
+	[327233] = 20, 		-- Belch Plague (Plagebelcher)
+	[320519] = 20, 		-- Jagged Spines (Blighted Spinebreaker)
+	[328501] = 20,		-- Plagued Bomb (Environement)
+	[324667] = 20,		-- Slime Wave (Globgrog)
+	[626242] = 20,		-- Slime Wave (Globgrog)
+	[333808] = 20,		-- Oozing Outbreak (Doctor Ickus)
+	[329217] = 20,		-- Slime Lunge (Doctor Ickus)
+	[322475] = 20,		-- Plague Crash (Environement Margrave Stradama)
+	
+	-- Theater of Pain
+	[337037] = 20,		-- Whirling Blade (Nekthara the Mangler)
+	[332708] = 20,		-- Ground Smash (Heavin the breaker)
+	[333297] = 20, 		-- Death Winds (Nefarious Darkspeaker)
+	[331243] = 20,		-- Bone Spikes (Soulforged Bonereaver)
+	[331224] = 20,		-- Bonestorm (Soulforged Bonereaver)
+	[330608] = 20,		-- Vile Eruption (Rancind Gasbag)
+	
+	[317231] = 20, 		-- Crushing Slam (Xav the Unfallen)
+	[339415] = 20,		-- Deafening Crash (Xav the Unfallen)
+	[320729] = 20,		-- Massive Cleave (Xav the Unfallen)
+	[318406] = 20,		-- Tenderizing Smash (Gorechop)
+	-- id ?[323542] = 20,		-- Oozing (Gorechop)
+	[323681] = 20,		-- Dark Devastation (Mordretha) 
+	[339573] = 20,		-- Echos of Carnage (Mordretha)
+	[339759] = 20,		-- Echos of Carnage (Mordretha)
+	
+	-- Sanguine Depths
+	[334563] = 20,		-- Volatile Trap (Dreadful Huntmaster)
+	[320991] = 20,		-- Echoing Thrust (Regal Mistdancer)
+	[320999] = 20,		-- Echoing Thrust (Regal Mistdancer Mirror)
+	-- id ?[321019] = 20,		-- Sanctified Mists (Regal Mistcaller)
+	[334921] = 20,		-- Umbral Crash (Insatiable Brute)
+	[322418] = 20,		-- Craggy Fracture (Chamber Sentinel)
+	[334378] = 20,      -- Explosive Vellum (Research Scribe)
+	[323573] = 20,      -- Residue (Fleeting Manifestation)
+	[325885] = 20,      -- Anguished Cries (Z'rali)
+	[334615] = 20,		-- Sweeping Slash (Head Custodian Javlin)
+	[322212] = 20,		-- Growing Mistrust (Vestige of Doubt)
+	[328494] = 20, 		-- Sintouched Anima (Environement)
+	[323810] = 20,		-- Piercing Blur (General Kaal)
+	
+	-- Hall of Atonement 
+	[325523] = 20,		-- Deadly Thrust (Depraved Darkblade)
+	[325799] = 20,		-- Rapid Fire (Depraved Houndmaster)
+	[326440] = 20,		-- Sin Quake (Shard of Halkias)
+	
+	[322945] = 20,		-- Heave Debris (Halkias)
+	[324044] = 20,		-- Refracted Sinlight (Halkias)
+	[319702] = 20,		-- Blood Torrent (Echelon)
+	[323126] = 20, 		-- Telekinetic Collision (Lord Chamberlain)
+    [329113] = 20,		-- Telekinteic Onslaught (Lord Chamberlain)
+	[327885] = 20,		-- Erupting Torment (Lord Chamberlain)
 }
 
 DE.SpellsNoTank = {
-	-- Freehold
-
-	-- Shrine of the Storm
+    -- Mists of Tirna Scythe
+	[331721] = 20,      --- Spear Flurry (Mistveil Defender)
 	
-	-- Siege of Boralus
-	[268230] = 20,		--- Crimson Swipe (Ashvane Deckhand)
+	-- De Other Side
 	
-	-- Tol Dagor
-	[258864] = 20,		--- Suppression Fire (Ashvane Marine/Spotter)
+	-- Spires of Ascension
+	[320966] = 20,      -- Overhead Slash (Kin-Tara)
+	[336444] = 20,      -- Crescendo (Forsworn Helion)
 	
-	-- Waycrest Manor
-	[263905] = 20,		--- Marking Cleave (Heartsbane Runeweaver)
-	[265372] = 20,		---	Shadow Cleave (Enthralled Guard)
-	[271174] = 20,		--- Retch (Pallid Gorger)
+	-- The Necrotic Wakes
+	[324323] = 20,		-- Gruesome Cleave (Skeletal Marauder)
+	-- Plaguefall
 	
-	-- Atal'Dazar
-
-	-- King's Rest
-	[270289] = 20,		--- Purification Beam (Purification Construct)
+	-- Theater of Pain
 	
-	-- The MOTHERLODE!!
-	[268846] = 20,		--- Echo Blade (Weapons Tester)
-	[263105] = 20,		--- Blowtorch (Feckless Assistant)
-	[263583] = 20,		--- Broad Slash (Taskmaster Askari)
-		
-	-- Temple of Sethraliss
-	[255741] = 20,		--- Cleave (Scaled Krolusk Rider)
-
-	-- Underrot
-	[272457] = 20,		--- Shockwave (Sporecaller Zancha)
-	[260793] = 20,		--- Indigestion (Cragmaw the Infested)
+	-- Sanguine Depths
+	[322429] = 20,		-- Severing Slice (Chamber Sentinel)
 	
+	-- Hall of Atonement 
+	-- id ? [118459] = 20,		-- Beast Cleave (Loyal Stoneborn)
+	[346866] = 20, 		-- Stone Breathe (Loyal Stoneborn)
+	[326997] = 20,		-- Powerful Swipe (Stoneborn Slasher)
 }
 
 DE.Auras = {
-	-- Freehold
-	[274516] = true,		-- Slippery Suds
+    -- Mists of Tirna Scythe
+    [323137] = true,      --- Bewildering Pollen (Drohman Oulfarran)
+	[321893] = true,      --- Freezing Burst (Illusionary Vulpin)
 	
-	-- Shrine of the Storm
-	[268391] = true,		-- Mental Assault (Abyssal Cultist)
-	[269104] = true,		-- Explosive Void (Lord Stormsong)
-	[267956] = true,		-- Zap (Jellyfish)
+	-- De Other Side
+	[331381] = 20,		-- Slipped (Lubricator)
 	
-	-- Siege of Boralus
-	[274942] = true,		-- Banana Stun
-	[257169] = true,		-- Fear
-
-	-- Tol Dagor
-	[256474] = true,		-- Heartstopper Venom (Overseer Korgus)
-
-	-- Waycrest Manor
-	[265352] = true,		-- Toad Blight (Toad)
-	[278468] = true,		-- Freezing Trap
+	-- Spires of Ascension
 	
-	-- Atal'Dazar
-	[255371] = true,		-- Terrifying Visage (Rezan)
-
-	-- King's Rest
-	[276031] = true,		-- Pit of Despair (Minion of Zul)
-
-	-- The MOTHERLODE!!
+	-- The Necrotic Wakes
 	
-	-- Temple of Sethraliss
-	[269970] = true,		-- Blinding Sand (Merektha)
-
-	-- Underrot
+	-- Plaguefall
 	
-	-- Mechagon Workshop
-	[293986] = true,		--- Sonic Pulse (Blastatron X-80)
+	-- Theater of Pain
 	
-	-- Mechaton Junkyard
-	[398529] = true,		-- Gooped (Gunker)
-	[300659] = true,		-- Consuming Slime (Toxic Monstrosity)
+	-- Sanguine Depths
+	
+	-- Hall of Atonement 
 }
 
 DE.AurasNoTank = {
-	[272140] = true,		--- Iron Volley
+
 }
 
 -- Public APIs


### PR DESCRIPTION
update spells for Shadowlands using current spell list from ElitismHelper