### PR TITLE
Fix volatile pufferfish spell id

### DIFF
--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -92,6 +92,8 @@ local Spells = {
     [324662] = 20, -- Ionized Plasma (Multiple) Can this be avoided?
     [324370] = 20, -- Attenuated Barrage (Kin-Tara)
     [324141] = 20, -- Dark Bolt (Ventunax)
+    [323372] = 20, -- Empyreal Ordnance (Oryphrion)
+    [323792] = 20, -- Anima Field (Oryphrion)
     [323943] = 20, -- Run Through (Devos)
     -- [] = 20,        -- Seed of the Abyss (Devos) ???
 

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -227,7 +227,7 @@ local Spells = {
     [347481] = 20, -- Shuri (So'azmi)
 
     -- Tazavesh: So'leah's Gambit
-    [355234] = 20, -- Volatile Pufferfish (Murkbrine Fishmancer) TODO verify
+    [355423] = 20, -- Volatile Pufferfish (Murkbrine Fishmancer)
     [355465] = 20, -- Boulder Throw (Coastwalker Goliath)
     [355581] = 20, -- Crackle (Stormforged Guardian)
     [355584] = 20, -- Charged Pulse (Stormforged Guardian)


### PR DESCRIPTION
This spell was recently hotfixed by Blizzard and now it finally does damage but under a different spell ID.