### PR TITLE
S3 Corrections

### DIFF
--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -306,6 +306,7 @@ local Spells = {
     [263098] = 20, -- Shadowy Remains (Echoes of Shadra, Yazma)
 
     -- Waycrest Manor
+    [265372] = 20, -- Shadow Cleave (Enthralled Guard)
     -- [278849] = 20, -- Uproot (Coven Thornshaper) - TODO probably not avoidable
     [264040] = 20, -- Uprooted Thorns (Coven Thornshaper)
     [264150] = 20, -- Shatter (Thornguard)
@@ -454,9 +455,6 @@ local SpellsNoTank = {
     [417339] = 20, -- Titanic Blow (Tyr, the Infinite Keeper)
     [404917] = 20, -- Sand Blast (Morchie)
     [416139] = 20, -- Temporal Breath (Chrono-Lord Deios)
-
-    -- Waycrest Manor
-    [265372] = 20, -- Shadow Cleave (Enthralled Guard)
 
     -- Black Rook Hold
     [225909] = 20, -- Soul Venom (Rook Spiderling)

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -376,7 +376,7 @@ local Spells = {
     [426991] = 20, -- Blazing Cinders (Archmage Sol)
     [428084] = 20, -- Glacial Fusion (Archmage Sol)
     [428148] = 20, -- Spatial Compression (Archmage Sol)
-    [169179] = 20, -- Colossal Blow (Yalnu) - always does damage to party as well
+    --[169179] = 20, -- Colossal Blow (Yalnu) - always does damage to party as well
     [428834] = 20, -- Verdant Eruption (Yalnu)
     [169930] = 20, -- Lumbering Swipe (Flourishing Ancient, Yalnu)
 
@@ -507,7 +507,10 @@ local Auras = {
     [199097] = true, -- Cloud of Hypnosis (Dantalionax, Lord Kur'talos Ravencrest)
 
     -- Darkheart Thicket
-    [200273] = true -- Cowardice (Shade of Xavius)
+    [200273] = true, -- Cowardice (Shade of Xavius)
+
+	-- The Everbloom
+	[169179] = true -- Colossal Blow (Yalnu)
 }
 
 local AurasNoTank = {}

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -289,7 +289,7 @@ local Spells = {
     [253654] = 20, -- Fiery Enchant (Dazar'ai Augur)
     [253666] = 20, -- Fiery Bolt (Dazar'ai Augur)
     [257692] = 20, -- Tiki Blaze (Environment)
-    [256884] = 20, -- Wild Thrash (Monzumi)
+    [255567] = 20, -- Frenzied Charge (T'lonja)
     [258723] = 20, -- Grotesque Pool (Reanimated Honor Guard)
     [255620] = 20, -- Festering Eruption (Reanimated Honor Guard)
 
@@ -347,12 +347,13 @@ local Spells = {
 
     -- Darkheart Thicket
     [218759] = 20, -- Corruption Pool (Nightmare Abomination, Festerhide Grizzly / Archdruid Glaidalis) - TODO check ID of boss version
+    [200771] = 20, -- Propelling Charge (Crazed Razorbeak)
     [204402] = 20, -- Star Shower (Dreadsoul Ruiner)
     [201123] = 20, -- Root Burst (Vilethorn Blossom)
     [198916] = 20, -- Vile Burst (Rotheart Keeper)
     [212797] = 20, -- Hatespawn Detonation (Hatespawn Whelpling) - TODO removed?
     [201273] = 20, -- Blood Bomb (Bloodtainted Fury)
-    [201227] = 20, -- Blood Assault (Bloodtainted Fury) - TODO is this avoidable for tanks?
+    [201227] = 20, -- Blood Assault (Bloodtainted Fury)
     [201842] = 20, -- Curse of Isolation (Taintheart Summoner)
 
     [198408] = 20, -- Nightfall (Archdruid Glaidalis)
@@ -386,7 +387,7 @@ local Spells = {
     -- Throne of the Tides
     [426685] = 20, -- Volatile Bolt (Naz'jar Ravager)
     [426688] = 20, -- Volatile Acid (Naz'jar Ravager)
-    [426681] = 20, -- Electric Jaws (Environment) - TODO ID?
+    [426681] = 20, -- Electric Jaws (Environment)
     [76590] = 20, -- Shadow Smash (Faceless Watcher)
     [426808] = 20, -- Null Blast (Faceless Seer)
 
@@ -462,7 +463,6 @@ local SpellsNoTank = {
 
     -- Darkheart Thicket
     [200589] = 20, -- Festering Swipe (Festerhide Grizzly) - TODO removed?
-    [200771] = 20, -- Propelling Charge (Crazed Razorbeak) - TODO is this avoidable for tanks?
     [198376] = 20, -- Primal Rampage, Frontal (Archdruid Glaidalis)
     [204667] = 20, -- Nightmare Breath (Oakheart)
 
@@ -475,8 +475,6 @@ local SpellsNoTank = {
     [169267] = 20, -- Toxic Blood (Toxic Spiderling, Xeri'tac) - not part of M+
 
     -- Throne of the Tides
-    [426645] = 20, -- Acid Barrage, Hit (Naz'jar Ravager)
-    [426727] = 20, -- Acid Barrage, DoT (Naz'jar Ravager)
     [428530] = 20 -- Murk Spew (Ink of Ozumat, Ozumat)
 }
 


### PR DESCRIPTION
AD - Wild Thrash no longer avoidable (range increased)
AD - Frenzied Charge now avoidable
DHT - Propelling Charge can be sidestepped by tanks
TotT - Acid Barrage was changed to random targets