### PR TITLE
Dragonflight Season 4

### DIFF
--- a/Spells/DungeonArchive/3-Cataclysm
+++ b/Spells/DungeonArchive/3-Cataclysm
@@ -1,4 +1,24 @@
 local Spells = {
+    -- Throne of the Tides
+    [426685] = 20, -- Volatile Bolt (Naz'jar Ravager)
+    [426688] = 20, -- Volatile Acid (Naz'jar Ravager)
+    [426681] = 20, -- Electric Jaws (Environment)
+    [76590] = 20, -- Shadow Smash (Faceless Watcher)
+    [426808] = 20, -- Null Blast (Faceless Seer)
+
+    [427769] = 20, -- Geyser (Lady Naz'jar)
+    [428048] = 20, -- Shock Orb (Lady Naz'jar)
+    [428294] = 20, -- Trident Flurry (Naz'jar Honor Guard, Lady Naz'jar)
+    [427565] = 20, -- Bubbling Fissure (Commander Ulthok)
+    [427559] = 20, -- Bubbling Ooze (Commander Ulthok)
+    [429057] = 20, -- Earthfury (Erunak Stonespeaker, Mindbender Ghur'sha)
+    [429172] = 20, -- Terrifying Vision (Mindbender Ghur'sha)
+    [428404] = 20, -- Blotting Darkness (Ink of Ozumat / Sludge, Ozumat)
+    [428616] = 20, -- Deluge of Filth (Ozumat)
+    [428618] = 20, -- Deluge of Filth (Ozumat)
+    [428809] = 20, -- Gushing Ink (Sludge, Ozumat)
+
+
     -- Vortex Pinnacle
     [410999] = 20, -- Pressurized Blast (Armored Mistral)
     -- [411001] = 20, -- Lethal Current (Lurking Tempest) - should this be considered avoidable?
@@ -17,7 +37,10 @@ local Spells = {
 }
 
 
-local SpellsNoTank = {}
+local SpellsNoTank = {
+    -- Throne of the Tides
+    [428530] = 20, -- Murk Spew (Ink of Ozumat, Ozumat)
+}
 
 local Auras = {}
 

--- a/Spells/DungeonArchive/5-Warlords_of_Draenor
+++ b/Spells/DungeonArchive/5-Warlords_of_Draenor
@@ -50,6 +50,27 @@ local Spells = {
     [161588] = 20, -- Diffused Energy (Skylord Tovra)
 
 
+    -- The Everbloom
+    [172579] = 20, -- Bounding Whirl (Melded Berserker)
+    [169495] = 20, -- Living Leaves (Gnarlroot)
+    [426849] = 20, -- Cold Fusion (Infested Icecaller)
+    [426982] = 20, -- Spatial Disruption (Addled Arcanomancer)
+
+    [177734] = 20, -- Agitated Water (Witherbark)
+    [164294] = 20, -- Unchecked Growth, Area (Witherbark)
+    [427922] = 20, -- Cinderbolt Storm, Swirlies (Archmage Sol)
+    [426991] = 20, -- Blazing Cinders (Archmage Sol)
+    [428084] = 20, -- Glacial Fusion (Archmage Sol)
+    [428148] = 20, -- Spatial Compression (Archmage Sol)
+    --[169179] = 20, -- Colossal Blow (Yalnu) - always does damage to party as well
+    [428834] = 20, -- Verdant Eruption (Yalnu)
+    [169930] = 20, -- Lumbering Swipe (Flourishing Ancient, Yalnu)
+
+    [172643] = 20, -- Descend (Xeri'tac) - not part of M+
+    [173081] = 20, -- Burst (Gorged Burster, Xeri'tac) - not part of M+
+    [169223] = 20, -- Toxic Gas (Xeri'tac / Toxic Spiderling, Xeri'tac) - not part of M+
+
+
     -- Shadowmoon Burial Grounds
     [152688] = 20, -- Shadow Rune (Environment)
     [152690] = 20, -- Shadow Rune (Environment)
@@ -87,6 +108,14 @@ local SpellsNoTank = {
     [164170] = 20, -- Dash (Grimrail Overseer) - always targets tank despite marker?
     [164163] = 20, -- Hewing Swipe (Grimrail Overseer)
 
+    -- The Everbloom
+    [164357] = 20, -- Parched Gasp (Witherbark)
+    [427512] = 20, -- Noxious Charge (Dulhu, Ancient Protectors)
+    [427513] = 20, -- Noxious Discharge (Dulhu, Ancient Protectors)
+    [170411] = 20, -- Spore Breath (Infested Venomfang) - not part of M+
+    [169371] = 20, -- Swipe (Venom-Crazed Pale One, Xeri'tac) - not part of M+
+    [169267] = 20, -- Toxic Blood (Toxic Spiderling, Xeri'tac) - not part of M+
+
     -- Shadowmoon Burial Grounds
     [153501] = 20, -- Void Blast (Nhallish)
 }
@@ -96,6 +125,9 @@ local Auras = {
      -- Iron Docks
     [164504] = true, -- Intimidated (Fleshrender Nok'gar)
     [172631] = true, -- Knocked Down (Slippery Grease, Grom'kar Technician)
+
+	-- The Everbloom
+	[169179] = true, -- Colossal Blow (Yalnu)
  }
 
 local AurasNoTank = {}

--- a/Spells/DungeonArchive/6-Legion
+++ b/Spells/DungeonArchive/6-Legion
@@ -1,22 +1,67 @@
 local Spells = {
-    -- Court of Stars
-    [209027] = 20, -- Quelling Strike (Duskwatch Guard)
-    [209477] = 20, -- Wild Detonation (Mana Wyrm)
-    [212031] = 20, -- Charged Blast (Bound Energy)
-    [209404] = 20, -- Seal Magic (Duskwatch Arcanist)
-    [211391] = 20, -- Felblaze Puddle (Legion Hound) - TODO is first tick avoidable?
+    -- Darkheart Thicket
+    [218759] = 20, -- Corruption Pool (Nightmare Abomination, Festerhide Grizzly / Archdruid Glaidalis) - TODO check ID of boss version
+    [200771] = 20, -- Propelling Charge (Crazed Razorbeak)
+    [204402] = 20, -- Star Shower (Dreadsoul Ruiner)
+    [201123] = 20, -- Root Burst (Vilethorn Blossom)
+    [198916] = 20, -- Vile Burst (Rotheart Keeper)
+    [212797] = 20, -- Hatespawn Detonation (Hatespawn Whelpling) - TODO removed?
+    [201273] = 20, -- Blood Bomb (Bloodtainted Fury)
+    [201227] = 20, -- Blood Assault (Bloodtainted Fury)
+    [201842] = 20, -- Curse of Isolation (Taintheart Summoner)
 
-    [206574] = 20, -- Resonant Slash, Front (Patrol Captain Gerdo)
-    [206580] = 20, -- Resonant Slash, Back (Patrol Captain Gerdo)
-    [219498] = 20, -- Streetsweeper (Patrol Captain Gerdo)
-    [209378] = 20, -- Whirling Blades (Imacu'tya, Talixae Flamewreath)
-    [207979] = 20, -- Shockwave (Jazshariu, Talixae Flamewreath)
-    [397903] = 20, -- Crushing Leap (Jazshariu, Talixae Flamewreath)
-    [207887] = 20, -- Infernal Eruption, Impact (Talixae Flamewreath)
-    [211457] = 20, -- Infernal Eruption, Area (Talixae Flamewreath)
-    [209628] = 20, -- Piercing Gale (Advisor Melandrus)
-    [209630] = 20, -- Piercing Gale (Image of Advisor Melandrus, Advisor Melandrus)
-    [209667] = 20, -- Blade Surge (Advisor Melandrus)
+    [198408] = 20, -- Nightfall (Archdruid Glaidalis)
+    [198386] = 20, -- Primal Rampage, Dash (Archdruid Glaidalis)
+    [199063] = 20, -- Strangling Roots (Oakheart)
+    [191326] = 20, -- Breath of Corruption (Dresaron)
+    [199460] = 20, -- Falling Rocks (Dresaron) - TODO is first tick avoidable?
+    [200329] = 20, -- Overwhelming Terror (Shade of Xavius)
+    [200111] = 20, -- Apocalyptic Fire (Shade of Xavius)
+
+
+    -- Black Rook Hold
+    [200261] = 20, -- Bonebreaking Strike (Soul-Torn Champion / Commander Shendah'sohn)
+    [200344] = 20, -- Arrow Barrage (Risen Archer)
+    [200256] = 20, -- Phased Explosion (Arcane Minion)
+    [222397] = 20, -- Boulder Crush (Environment)
+    [201175] = 20, -- Throw Priceless Artifact (Wyrmtongue Scavenger)
+    [200914] = 20, -- Indigestion (Wyrmtongue Scavenger)
+    [201062] = 20, -- Bowled Over! (Wyrmtongue Scavenger)
+    [214002] = 20, -- Raven's Dive (Risen Lancer)
+
+    [196517] = 20, -- Swirling Scythe (Amalgam of Souls)
+    [194960] = 20, -- Soul Echoes, Explosion (Lord Etheldrin Ravencrest / Amalgam of Souls)
+    [194956] = 20, -- Reap Soul (Amalgam of Souls)
+    [197521] = 20, -- Blazing Trail (Illysanna Ravencrest)
+    [197821] = 20, -- Felblazed Ground (Illysanna Ravencrest)
+    [197974] = 20, -- Bonecrushing Strike (Soul-Torn Vanguard, Illysanna Ravencrest)
+    [198501] = 20, -- Fel Vomitus (Fel Bat, Smashspite the Hateful)
+    [198781] = 20, -- Whirling Blade (Lord Kur'talos Ravencrest)
+    [198820] = 20, -- Dark Blast (Latosius, Lord Kur'talos Ravencrest)
+    [199567] = 20, -- Dark Obliteration (Image of Latosius, Lord Kur'talos Ravencrest)
+
+
+    -- Neltharion's Lair
+    [183407] = 20, -- Acid Splatter (Vileshard Crawler)
+    [183465] = 20, -- Viscid Bile (Tarspitter Lurker)
+    [226388] = 20, -- Rancid Ooze (Tarspitter Luker)
+    [226287] = 20, -- Crush (Vileshard Chunk)
+    [183088] = 20, -- Avalanche, Frontal (Mightstone Breaker)
+    [183100] = 20, -- Avalanche, Rocks (Mightstone Breaker)
+    [186576] = 20, -- Petrifying Cloud (Petrifying Totem, Blightshard Shaper)
+    [202089] = 20, -- Scorch (Burning Geode)
+    -- [183566] = 20, -- Rancid Pool (Rotdrool Grabber, Stoneclaw Grubmaster) - not really avoidable
+
+    [198028] = 20, -- Crystalline Ground (Rokmora)
+    [188169] = 20, -- Razor Shards (Rokmora)
+    [192800] = 20, -- Choking Dust (Blightshard Skitter, Rokmora)
+    [198475] = 20, -- Strike of the Mountain (Ularogg Cragshaper)
+    [210166] = 20, -- Toxic Retch, Area (Naraxas)
+    [199705] = 20, -- Devouring (Naraxas)
+    [200338] = 20, -- Crystal Spikes (Dargrul)
+    [217090] = 20, -- Magma Wave, Initial (Dargrul)
+    [200404] = 20, -- Magma Wave, Final (Dargrul)
+    [216407] = 20, -- Lava Geyser (Dargrul)
 
 
     -- Halls of Valor
@@ -41,27 +86,24 @@ local Spells = {
     [198412] = 20, -- Feedback (Odyn)
 
 
-    -- Neltharion's Lair
-    [183407] = 20, -- Acid Splatter (Vileshard Crawler)
-    [183465] = 20, -- Viscid Bile (Tarspitter Lurker)
-    [226388] = 20, -- Rancid Ooze (Tarspitter Luker)
-    [226287] = 20, -- Crush (Vileshard Chunk)
-    [183088] = 20, -- Avalanche, Frontal (Mightstone Breaker)
-    [183100] = 20, -- Avalanche, Rocks (Mightstone Breaker)
-    [186576] = 20, -- Petrifying Cloud (Petrifying Totem, Blightshard Shaper)
-    [202089] = 20, -- Scorch (Burning Geode)
-    -- [183566] = 20, -- Rancid Pool (Rotdrool Grabber, Stoneclaw Grubmaster) - not really avoidable
+    -- Court of Stars
+    [209027] = 20, -- Quelling Strike (Duskwatch Guard)
+    [209477] = 20, -- Wild Detonation (Mana Wyrm)
+    [212031] = 20, -- Charged Blast (Bound Energy)
+    [209404] = 20, -- Seal Magic (Duskwatch Arcanist)
+    [211391] = 20, -- Felblaze Puddle (Legion Hound) - TODO is first tick avoidable?
 
-    [198028] = 20, -- Crystalline Ground (Rokmora)
-    [188169] = 20, -- Razor Shards (Rokmora)
-    [192800] = 20, -- Choking Dust (Blightshard Skitter, Rokmora)
-    [198475] = 20, -- Strike of the Mountain (Ularogg Cragshaper)
-    [210166] = 20, -- Toxic Retch, Area (Naraxas)
-    [199705] = 20, -- Devouring (Naraxas)
-    [200338] = 20, -- Crystal Spikes (Dargrul)
-    [217090] = 20, -- Magma Wave, Initial (Dargrul)
-    [200404] = 20, -- Magma Wave, Final (Dargrul)
-    [216407] = 20, -- Lava Geyser (Dargrul)
+    [206574] = 20, -- Resonant Slash, Front (Patrol Captain Gerdo)
+    [206580] = 20, -- Resonant Slash, Back (Patrol Captain Gerdo)
+    [219498] = 20, -- Streetsweeper (Patrol Captain Gerdo)
+    [209378] = 20, -- Whirling Blades (Imacu'tya, Talixae Flamewreath)
+    [207979] = 20, -- Shockwave (Jazshariu, Talixae Flamewreath)
+    [397903] = 20, -- Crushing Leap (Jazshariu, Talixae Flamewreath)
+    [207887] = 20, -- Infernal Eruption, Impact (Talixae Flamewreath)
+    [211457] = 20, -- Infernal Eruption, Area (Talixae Flamewreath)
+    [209628] = 20, -- Piercing Gale (Advisor Melandrus)
+    [209630] = 20, -- Piercing Gale (Image of Advisor Melandrus, Advisor Melandrus)
+    [209667] = 20, -- Blade Surge (Advisor Melandrus)
 
 
     -- Return to Karazhan: Lower
@@ -123,15 +165,13 @@ local Spells = {
 
 
 local SpellsNoTank = {
-    -- Court of Stars
-    [209036] = 20, -- Throw Torch (Duskwatch Sentry)
-    [209495] = 20, -- Charged Smash (Guardian Construct)
-    [209512] = 20, -- Disrupting Energy (Guardian Construct)
+    -- Darkheart Thicket
+    [200589] = 20, -- Festering Swipe (Festerhide Grizzly) - TODO removed?
+    [198376] = 20, -- Primal Rampage, Frontal (Archdruid Glaidalis)
+    [204667] = 20, -- Nightmare Breath (Oakheart)
 
-    -- Halls of Valor
-    [198888] = 20, -- Lightning Breath (Storm Drake) - TODO is this avoidable by tank?
-    [199050] = 20, -- Mortal Hew (Valarjar Shieldmaiden)
-    [192018] = 20, -- Shield of Light (Hyrja)
+    -- Black Rook Hold
+    [225909] = 20, -- Soul Venom (Rook Spiderling)
 
     -- Neltharion's Lair
     [193505] = 20, -- Fracture (Vileshard Hulk)
@@ -142,6 +182,16 @@ local SpellsNoTank = {
     [188494] = 20, -- Rancid Maw (Naraxas)
     [205609] = 20, -- Rancid Maw (Naraxas) - TODO ID?
     [200721] = 20 -- Landslide (Dargrul)
+
+    -- Halls of Valor
+    [198888] = 20, -- Lightning Breath (Storm Drake) - TODO is this avoidable by tank?
+    [199050] = 20, -- Mortal Hew (Valarjar Shieldmaiden)
+    [192018] = 20, -- Shield of Light (Hyrja)
+
+    -- Court of Stars
+    [209036] = 20, -- Throw Torch (Duskwatch Sentry)
+    [209495] = 20, -- Charged Smash (Guardian Construct)
+    [209512] = 20, -- Disrupting Energy (Guardian Construct)
 
     -- Return to Karazhan: Lower
     [99758] = 20, -- Flame Breath (Ancient Core Hound)
@@ -160,6 +210,12 @@ local SpellsNoTank = {
 
 
 local Auras = {
+    -- Darkheart Thicket
+    [200273] = true, -- Cowardice (Shade of Xavius)
+
+    -- Black Rook Hold
+    [199097] = true, -- Cloud of Hypnosis (Dantalionax, Lord Kur'talos Ravencrest)
+
     -- Court of Stars
     [214987] = true, -- Righteous Indignation (Suspicious Noble) - TODO find ID for stun
     [224333] = true, -- Enveloping Winds (Advisor Melandrus)

--- a/Spells/DungeonArchive/7-Battle_for_Azeroth
+++ b/Spells/DungeonArchive/7-Battle_for_Azeroth
@@ -1,4 +1,25 @@
 local Spells = {
+    -- Atal'Dazar
+    [253654] = 20, -- Fiery Enchant (Dazar'ai Augur)
+    [253666] = 20, -- Fiery Bolt (Dazar'ai Augur)
+    [257692] = 20, -- Tiki Blaze (Environment)
+    [255567] = 20, -- Frenzied Charge (T'lonja)
+    [258723] = 20, -- Grotesque Pool (Reanimated Honor Guard)
+    [255620] = 20, -- Festering Eruption (Reanimated Honor Guard)
+
+    [258709] = 20, -- Corrupted Gold (Priestess Alun'za)
+    [255373] = 20, -- Tail (Rezan)
+    [255445] = 20, -- Devour (Rezan)
+    [250259] = 20, -- Toxic Leap (Vol'kaal)
+    [250585] = 20, -- Toxic Pool (Vol'kaal)
+    [250028] = 20, -- Echoes of Shadra, Swirly (Yazma)
+    [263093] = 20, -- Echoes of Shadra, Swirly (Yazma)
+    [250022] = 20, -- Echoes of Shadra, Explosion (Echoes of Shadra, Yazma)
+    [263096] = 20, -- Echoes of Shadra, Explosion (Echoes of Shadra, Yazma)
+    [250036] = 20, -- Shadowy Remains (Echoes of Shadra, Yazma)
+    [263098] = 20, -- Shadowy Remains (Echoes of Shadra, Yazma)
+
+
     -- The Underrot
     [265540] = 20, -- Rotten Bile (Fetid Maggot)
     [265542] = 20, -- Rotten Bile (Fetid Maggot)
@@ -53,6 +74,27 @@ local Spells = {
     [413146] = 20, -- Swiftwind Saber (Harlan Sweete)
     [257293] = 20, -- Swiftwind Saber (Harlan Sweete) - TODO ID?
     [257315] = 20, -- Black Powder Bomb (Irontide Grenadier, Harlan Sweete)
+
+
+    -- Waycrest Manor
+    [265372] = 20, -- Shadow Cleave (Enthralled Guard)
+    -- [278849] = 20, -- Uproot (Coven Thornshaper) - TODO probably not avoidable
+    [264040] = 20, -- Uprooted Thorns (Coven Thornshaper)
+    [264150] = 20, -- Shatter (Thornguard)
+    [265757] = 20, -- Splinter Spike (Matron Bryndle)
+    [264531] = 20, -- Shrapnel Trap (Maddened Survivalist)
+    [271174] = 20, -- Retch (Pallid Gorger)
+    [265407] = 20, -- Dinner Bell (Banquet Steward)
+
+    [260570] = 20, -- Wildfire, Swirly (Soulbound Goliath)
+    [260569] = 20, -- Wildfire, Area (Soulbound Goliath)
+    [272669] = 20, -- Burning Fists (Burning Soul, Soulbound Goliath)
+    [264923] = 20, -- Tenderize (Raal the Gluttonous)
+    [264698] = 20, -- Rotten Expulsion, Impact (Raal the Gluttonous)
+    [264712] = 20, -- Rotten Expulsion, Area (Raal the Gluttonous)
+    [268234] = 20, -- Bile Explosion (Bile Oozeling, Raal the Gluttonous)
+    [268387] = 20, -- Contagious Remnants (Lord Waycrest)
+    [268308] = 20, -- Discordant Cadenza (Lady Waycrest)
 
 
     -- Operation: Mechagon - Junkyard
@@ -121,9 +163,17 @@ local SpellsNoTank = {
 
 
 local Auras = {
+    -- Atal'Dazar
+    [257483] = true, -- Pile of Bones (Environment, Rezan)
+    [255371] = true, -- Terrifying Visage (Rezan)
+
     -- Freehold
     [274516] = true, -- Slippery Suds (Bilge Rat Swabby)
     [272554] = true -- Bloody Mess (Trothak, Ring of Booty)
+
+    -- Waycrest Manor
+    [265352] = true, -- Toad Blight (Blight Toad)
+    [278468] = true, -- Freezing Trap (Maddened Survivalist)
 
     -- Operation: Mechagon - Junkyard
     [398529] = true, -- Gooped (Gunker)

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -20,6 +20,7 @@ local Spells = {
     [394873] = 20, -- Lightning Strike (Thundering, Environment)
     [396411] = 20, -- Primal Overload (Thundering, Environment)
 
+
     -- Uldaman: Legacy of Tyr
     [369811] = 20, -- Brutal Slam (Hulking Berserker)
     [369854] = 20, -- Throw Rock (Burly Rock-Thrower)
@@ -35,6 +36,7 @@ local Spells = {
     [369052] = 20, -- Seeking Flame (Vault Keeper, Emberon)
     [376325] = 20, -- Eternity Zone (Chrono-Lord Deios)
     [377561] = 20, -- Time Eruption (Chrono-Lord Deios)
+
 
     -- Ruby Life Pools
     [372696] = 20, -- Excavating Blast (Primal Juggernaut)
@@ -61,6 +63,7 @@ local Spells = {
     [373087] = 20, -- Burnout (Blazebound Firestorm, Kokia Blazehoof)
     [381526] = 20, -- Roaring Firebreath (Kyrakka)
     [384773] = 20, -- Flaming Embers (Kyrakka)
+
 
     -- Neltharus
     [372459] = 20, -- Burning (Environment)
@@ -92,6 +95,7 @@ local Spells = {
     [377477] = 20, -- Burning Ember (Warlord Sargha)
     [377542] = 20, -- Burning Ground (Warlord Sargha)
     [391773] = 20, -- The Dragon's Eruption (Warlord Sargha)
+
 
     -- The Nokhud Offensive
     [384868] = 20, -- Multi-Shot (Nokhud Longbow)
@@ -126,6 +130,7 @@ local Spells = {
     [376892] = 20, -- Crackling Upheaval (Balakar Khan)
     [376899] = 20, -- Crackling Cloud (Balakar Khan) - TODO is first tick avoidable?
 
+
     -- Brackenhide Hollow
     [368297] = 20, -- Toxic Trap, Trigger (Bonebolt Hunter)
     [368299] = 20, -- Toxic Trap, Area (Bonebolt Hunter)
@@ -151,6 +156,7 @@ local Spells = {
     [376149] = 20, -- Choking Rotcloud, Area (Decatriarch Wratheye)
     [379425] = 20, -- Decaying Fog (Environment, Decatriarch Wratheye)
 
+
     -- The Azure Vault
     [370766] = 20, -- Crystalline Rupture (Crystal Thrasher)
     [371021] = 20, -- Splintering Shards, Aura (Crystal Thrasher)
@@ -171,6 +177,7 @@ local Spells = {
     [384699] = 20, -- Crystalline Roar (Umbrelskul)
     [385078] = 20, -- Arcane Eruption (Umbrelskul)
     [385267] = 20, -- Crackling Vortex (Umbrelskul)
+
 
     -- Halls of Infusion
     [374075] = 20, -- Seismic Slam (Primalist Geomancer)
@@ -197,6 +204,7 @@ local Spells = {
     [387363] = 20, -- Infused Globule, Explosion (Primal Tsunami)
     [388786] = 20, -- Rogue Waves (Primal Tsunami)
 
+
     -- Algeth'ar Academy
     [388884] = 20, -- Arcane Rain (Spellbound Scepter)
     [388957] = 20, -- Riftbreath (Arcane Ravager)
@@ -219,6 +227,7 @@ local Spells = {
     [374361] = 20, -- Astral Breath (Echo of Doragosa)
     [389007] = 20, -- Arcane Rift / Wild Energy (Echo of Doragosa)
     [388996] = 20, -- Energy Eruption (Echo of Doragosa)
+
 
     -- Dawn of the Infinite: Galakrond's Fall
     [419447] = 20, -- Bronze Radiance (Environment)
@@ -246,6 +255,7 @@ local Spells = {
     [414376] = 20, -- Punctured Ground (Iridikron)
     [409642] = 20, -- Pulverizing Exhalation (Iridikron)
     [409969] = 20, -- Stone Dispersion (Iridikron)
+
 
     -- Dawn of the Infinite: Murozond's Rise
     [412137] = 20, -- Temporal Strike (Valow, Timesworn Keeper)
@@ -284,125 +294,6 @@ local Spells = {
     [416265] = 20, -- Infinite Corruption, small Swirlies (Chrono-Lord Deios)
     [416266] = 20, -- Infinite Corruption, big Swirlies (Chrono-Lord Deios)
     [417413] = 20, -- Temporal Scar (Chrono-Lord Deios)
-
-    -- Atal'Dazar
-    [253654] = 20, -- Fiery Enchant (Dazar'ai Augur)
-    [253666] = 20, -- Fiery Bolt (Dazar'ai Augur)
-    [257692] = 20, -- Tiki Blaze (Environment)
-    [255567] = 20, -- Frenzied Charge (T'lonja)
-    [258723] = 20, -- Grotesque Pool (Reanimated Honor Guard)
-    [255620] = 20, -- Festering Eruption (Reanimated Honor Guard)
-
-    [258709] = 20, -- Corrupted Gold (Priestess Alun'za)
-    [255373] = 20, -- Tail (Rezan)
-    [255445] = 20, -- Devour (Rezan)
-    [250259] = 20, -- Toxic Leap (Vol'kaal)
-    [250585] = 20, -- Toxic Pool (Vol'kaal)
-    [250028] = 20, -- Echoes of Shadra, Swirly (Yazma)
-    [263093] = 20, -- Echoes of Shadra, Swirly (Yazma)
-    [250022] = 20, -- Echoes of Shadra, Explosion (Echoes of Shadra, Yazma)
-    [263096] = 20, -- Echoes of Shadra, Explosion (Echoes of Shadra, Yazma)
-    [250036] = 20, -- Shadowy Remains (Echoes of Shadra, Yazma)
-    [263098] = 20, -- Shadowy Remains (Echoes of Shadra, Yazma)
-
-    -- Waycrest Manor
-    [265372] = 20, -- Shadow Cleave (Enthralled Guard)
-    -- [278849] = 20, -- Uproot (Coven Thornshaper) - TODO probably not avoidable
-    [264040] = 20, -- Uprooted Thorns (Coven Thornshaper)
-    [264150] = 20, -- Shatter (Thornguard)
-    [265757] = 20, -- Splinter Spike (Matron Bryndle)
-    [264531] = 20, -- Shrapnel Trap (Maddened Survivalist)
-    [271174] = 20, -- Retch (Pallid Gorger)
-    [265407] = 20, -- Dinner Bell (Banquet Steward)
-
-    [260570] = 20, -- Wildfire, Swirly (Soulbound Goliath)
-    [260569] = 20, -- Wildfire, Area (Soulbound Goliath)
-    [272669] = 20, -- Burning Fists (Burning Soul, Soulbound Goliath)
-    [264923] = 20, -- Tenderize (Raal the Gluttonous)
-    [264698] = 20, -- Rotten Expulsion, Impact (Raal the Gluttonous)
-    [264712] = 20, -- Rotten Expulsion, Area (Raal the Gluttonous)
-    [268234] = 20, -- Bile Explosion (Bile Oozeling, Raal the Gluttonous)
-    [268387] = 20, -- Contagious Remnants (Lord Waycrest)
-    [268308] = 20, -- Discordant Cadenza (Lady Waycrest)
-
-    -- Black Rook Hold
-    [200261] = 20, -- Bonebreaking Strike (Soul-Torn Champion / Commander Shendah'sohn)
-    [200344] = 20, -- Arrow Barrage (Risen Archer)
-    [200256] = 20, -- Phased Explosion (Arcane Minion)
-    [222397] = 20, -- Boulder Crush (Environment)
-    [201175] = 20, -- Throw Priceless Artifact (Wyrmtongue Scavenger)
-    [200914] = 20, -- Indigestion (Wyrmtongue Scavenger)
-    [201062] = 20, -- Bowled Over! (Wyrmtongue Scavenger)
-    [214002] = 20, -- Raven's Dive (Risen Lancer)
-
-    [196517] = 20, -- Swirling Scythe (Amalgam of Souls)
-    [194960] = 20, -- Soul Echoes, Explosion (Lord Etheldrin Ravencrest / Amalgam of Souls)
-    [194956] = 20, -- Reap Soul (Amalgam of Souls)
-    [197521] = 20, -- Blazing Trail (Illysanna Ravencrest)
-    [197821] = 20, -- Felblazed Ground (Illysanna Ravencrest)
-    [197974] = 20, -- Bonecrushing Strike (Soul-Torn Vanguard, Illysanna Ravencrest)
-    [198501] = 20, -- Fel Vomitus (Fel Bat, Smashspite the Hateful)
-    [198781] = 20, -- Whirling Blade (Lord Kur'talos Ravencrest)
-    [198820] = 20, -- Dark Blast (Latosius, Lord Kur'talos Ravencrest)
-    [199567] = 20, -- Dark Obliteration (Image of Latosius, Lord Kur'talos Ravencrest)
-
-    -- Darkheart Thicket
-    [218759] = 20, -- Corruption Pool (Nightmare Abomination, Festerhide Grizzly / Archdruid Glaidalis) - TODO check ID of boss version
-    [200771] = 20, -- Propelling Charge (Crazed Razorbeak)
-    [204402] = 20, -- Star Shower (Dreadsoul Ruiner)
-    [201123] = 20, -- Root Burst (Vilethorn Blossom)
-    [198916] = 20, -- Vile Burst (Rotheart Keeper)
-    [212797] = 20, -- Hatespawn Detonation (Hatespawn Whelpling) - TODO removed?
-    [201273] = 20, -- Blood Bomb (Bloodtainted Fury)
-    [201227] = 20, -- Blood Assault (Bloodtainted Fury)
-    [201842] = 20, -- Curse of Isolation (Taintheart Summoner)
-
-    [198408] = 20, -- Nightfall (Archdruid Glaidalis)
-    [198386] = 20, -- Primal Rampage, Dash (Archdruid Glaidalis)
-    [199063] = 20, -- Strangling Roots (Oakheart)
-    [191326] = 20, -- Breath of Corruption (Dresaron)
-    [199460] = 20, -- Falling Rocks (Dresaron) - TODO is first tick avoidable?
-    [200329] = 20, -- Overwhelming Terror (Shade of Xavius)
-    [200111] = 20, -- Apocalyptic Fire (Shade of Xavius)
-
-    -- The Everbloom
-    [172579] = 20, -- Bounding Whirl (Melded Berserker)
-    [169495] = 20, -- Living Leaves (Gnarlroot)
-    [426849] = 20, -- Cold Fusion (Infested Icecaller)
-    [426982] = 20, -- Spatial Disruption (Addled Arcanomancer)
-
-    [177734] = 20, -- Agitated Water (Witherbark)
-    [164294] = 20, -- Unchecked Growth, Area (Witherbark)
-    [427922] = 20, -- Cinderbolt Storm, Swirlies (Archmage Sol)
-    [426991] = 20, -- Blazing Cinders (Archmage Sol)
-    [428084] = 20, -- Glacial Fusion (Archmage Sol)
-    [428148] = 20, -- Spatial Compression (Archmage Sol)
-    --[169179] = 20, -- Colossal Blow (Yalnu) - always does damage to party as well
-    [428834] = 20, -- Verdant Eruption (Yalnu)
-    [169930] = 20, -- Lumbering Swipe (Flourishing Ancient, Yalnu)
-
-    [172643] = 20, -- Descend (Xeri'tac) - not part of M+
-    [173081] = 20, -- Burst (Gorged Burster, Xeri'tac) - not part of M+
-    [169223] = 20, -- Toxic Gas (Xeri'tac / Toxic Spiderling, Xeri'tac) - not part of M+
-
-    -- Throne of the Tides
-    [426685] = 20, -- Volatile Bolt (Naz'jar Ravager)
-    [426688] = 20, -- Volatile Acid (Naz'jar Ravager)
-    [426681] = 20, -- Electric Jaws (Environment)
-    [76590] = 20, -- Shadow Smash (Faceless Watcher)
-    [426808] = 20, -- Null Blast (Faceless Seer)
-
-    [427769] = 20, -- Geyser (Lady Naz'jar)
-    [428048] = 20, -- Shock Orb (Lady Naz'jar)
-    [428294] = 20, -- Trident Flurry (Naz'jar Honor Guard, Lady Naz'jar)
-    [427565] = 20, -- Bubbling Fissure (Commander Ulthok)
-    [427559] = 20, -- Bubbling Ooze (Commander Ulthok)
-    [429057] = 20, -- Earthfury (Erunak Stonespeaker, Mindbender Ghur'sha)
-    [429172] = 20, -- Terrifying Vision (Mindbender Ghur'sha)
-    [428404] = 20, -- Blotting Darkness (Ink of Ozumat / Sludge, Ozumat)
-    [428616] = 20, -- Deluge of Filth (Ozumat)
-    [428618] = 20, -- Deluge of Filth (Ozumat)
-    [428809] = 20 -- Gushing Ink (Sludge, Ozumat)
 }
 
 local SpellsNoTank = {
@@ -455,25 +346,6 @@ local SpellsNoTank = {
     [417339] = 20, -- Titanic Blow (Tyr, the Infinite Keeper)
     [404917] = 20, -- Sand Blast (Morchie)
     [416139] = 20, -- Temporal Breath (Chrono-Lord Deios)
-
-    -- Black Rook Hold
-    [225909] = 20, -- Soul Venom (Rook Spiderling)
-
-    -- Darkheart Thicket
-    [200589] = 20, -- Festering Swipe (Festerhide Grizzly) - TODO removed?
-    [198376] = 20, -- Primal Rampage, Frontal (Archdruid Glaidalis)
-    [204667] = 20, -- Nightmare Breath (Oakheart)
-
-    -- The Everbloom
-    [164357] = 20, -- Parched Gasp (Witherbark)
-    [427512] = 20, -- Noxious Charge (Dulhu, Ancient Protectors)
-    [427513] = 20, -- Noxious Discharge (Dulhu, Ancient Protectors)
-    [170411] = 20, -- Spore Breath (Infested Venomfang) - not part of M+
-    [169371] = 20, -- Swipe (Venom-Crazed Pale One, Xeri'tac) - not part of M+
-    [169267] = 20, -- Toxic Blood (Toxic Spiderling, Xeri'tac) - not part of M+
-
-    -- Throne of the Tides
-    [428530] = 20 -- Murk Spew (Ink of Ozumat, Ozumat)
 }
 
 local Auras = {
@@ -492,23 +364,6 @@ local Auras = {
 
     -- Dawn of the Infinite: Murozond's Rise
     [401667] = true, -- Time Stasis (Morchie)
-
-    -- Atal'Dazar
-    [257483] = true, -- Pile of Bones (Environment, Rezan)
-    [255371] = true, -- Terrifying Visage (Rezan)
-
-    -- Waycrest Manor
-    [265352] = true, -- Toad Blight (Blight Toad)
-    [278468] = true, -- Freezing Trap (Maddened Survivalist)
-
-    -- Black Rook Hold
-    [199097] = true, -- Cloud of Hypnosis (Dantalionax, Lord Kur'talos Ravencrest)
-
-    -- Darkheart Thicket
-    [200273] = true, -- Cowardice (Shade of Xavius)
-
-	-- The Everbloom
-	[169179] = true -- Colossal Blow (Yalnu)
 }
 
 local AurasNoTank = {}

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -41,7 +41,6 @@ local Spells = {
     -- Ruby Life Pools
     [372696] = 20, -- Excavating Blast (Primal Juggernaut)
     [372697] = 20, -- Jagged Earth (Primal Juggernaut)
-    [373458] = 20, -- Stone Missile (Primal Terrasentry)
     [372088] = 20, -- Blazing Rush, Hit (Defier Draghar)
     [372796] = 20, -- Blazing Rush, DoT (Defier Draghar)
     [385292] = 20, -- Molten Steel (Defier Draghar)
@@ -81,11 +80,12 @@ local Spells = {
     [378831] = 20, -- Explosive Concoction (Qalashi Plunderer)
 
     [373756] = 20, -- Magma Wave (Chargath, Bane of Scales)
+    [374854] = 20, -- Erupted Ground (Chargath, Bane of Scales)
     [375397] = 20, -- Lava Splash (Chargath, Bane of Scales)
     [375061] = 20, -- Blazing Eruption (Forgemaster Gorek)
     [375241] = 20, -- Forgestorm (Forgemaster Gorek)
-    [374397] = 20, -- Heated Swings, Jump (Forgemaster Gorek) - TODO which one is correct?
-    [374517] = 20, -- Heated Swings, Jump (Forgemaster Gorek) - TODO which one is correct?
+    [374397] = 20, -- Heated Swings, Jump (Forgemaster Gorek)
+    [374517] = 20, -- Heated Swings, Jump (Forgemaster Gorek)
     [381482] = 20, -- Forgefire (Forgemaster Gorek)
     [375071] = 20, -- Magma Lob (Magmatusk)
     [375204] = 20, -- Liquid Hot Magma (Magmatusk)
@@ -98,7 +98,6 @@ local Spells = {
 
 
     -- The Nokhud Offensive
-    [384868] = 20, -- Multi-Shot (Nokhud Longbow)
     [384479] = 20, -- Rain of Arrows (Nokhud Longbow)
     [384336] = 20, -- War Stomp (Nokhud Plainstomper / Nokhud Lancemaster / Nokhud Defender)
     [386028] = 20, -- Thunder Clap (Primalist Thunderbeast)
@@ -107,7 +106,6 @@ local Spells = {
     [386912] = 20, -- Stormsurge Cloud (Stormsurge Totem)
     [396376] = 20, -- Chant of the Dead (Ukhel Deathspeaker)
     [387611] = 20, -- Necrotic Eruption (Ukhel Corruptor)
-    [387629] = 20, -- Rotting Wind (Desecrated Ohuna)
     [388451] = 20, -- Stormcaller's Fury (Environment)
     [382233] = 20, -- Broad Stomp (Nokhud Defender / Batak)
     [382274] = 20, -- Vehement Charge (Nokhud Defender / Balara)
@@ -143,6 +141,7 @@ local Spells = {
     [385303] = 20, -- Teeth Trap (Environment)
     [385524] = 20, -- Sentry Fire (Environment)
     [385805] = 20, -- Violent Whirlwind (Stinkbreath)
+    [385186] = 20, -- Stink Breath (Stinkbreath)
     [379425] = 20, -- Rotting Creek (Environment)
     [383392] = 20, -- Rotting Surge, Impact (Filth Caller)
     [383399] = 20, -- Rotting Surge, periodic (Filth Caller)
@@ -168,7 +167,6 @@ local Spells = {
     [386536] = 20, -- Null Stomp (Nullmagic Hornswog)
 
     [374523] = 20, -- Stinging Sap (Leymor)
-    [386660] = 20, -- Erupting Fissure (Leymor)
     [374582] = 20, -- Explosive Brand, Area (Leymor)
     [385579] = 20, -- Ancient Orb (Azureblade)
     [390462] = 20, -- Ancient Orb Fragment (Azureblade)
@@ -187,7 +185,6 @@ local Spells = {
     [374563] = 20, -- Dazzle (Dazzling Dragonfly)
     [374741] = 20, -- Magma Crush (Flamecaller Aymi)
     [375080] = 20, -- Whirling Fury (Squallbringer Cyraz)
-    [385168] = 20, -- Thunderstorm (Primalist Galesinger) - TODO is first tick avoidable?
     [375384] = 20, -- Rumbling Earth (Primalist Earthshaker)
     [383204] = 20, -- Crashing Tsunami (Environment)
     [390290] = 20, -- Flash Flood (Infuser Sariya)
@@ -206,7 +203,6 @@ local Spells = {
 
 
     -- Algeth'ar Academy
-    [388884] = 20, -- Arcane Rain (Spellbound Scepter)
     [388957] = 20, -- Riftbreath (Arcane Ravager)
     [378011] = 20, -- Deadly Winds (Guardian Sentry)
     [377516] = 20, -- Dive Bomb (Territorial Eagle)
@@ -216,7 +212,7 @@ local Spells = {
     [387932] = 20, -- Astral Whirlwind (Algeth'ar Echoknight)
 
     [385970] = 20, -- Arcane Orb, Spawn (Vexamus)
-    [386201] = 20, -- Corrupted Mana (Vexamus) - TODO is first tick avoidable?
+    [386201] = 20, -- Corrupted Mana (Vexamus)
     [388546] = 20, -- Arcane Fissure, Swirly (Vexamus)
     [377034] = 20, -- Overpowering Gust (Crawth)
     [376449] = 20, -- Firestorm (Crawth)
@@ -303,9 +299,6 @@ local SpellsNoTank = {
     [369061] = 20, -- Searing Clap (Emberon)
     [375727] = 20, -- Sand Breath (Chrono-Lord Deios)
 
-    -- Neltharus
-    [384019] = 20, -- Fiery Focus (Chargath, Bane of Scales)
-
     -- The Nokhud Offensive
     [384512] = 20, -- Cleaving Strikes (Nokhud Lancemaster / Nokhud Defender)
     [387135] = 20, -- Arcing Strike (Primalist Arcblade)
@@ -322,6 +315,7 @@ local SpellsNoTank = {
     [370764] = 20, -- Piercing Shards (Crystal Fury)
     [391120] = 20, -- Spellfrost Breath (Scalebane Lieutenant)
     [372222] = 20, -- Arcane Cleave (Azureblade)
+    [386660] = 20, -- Erupting Fissure (Leymor)
 
     -- Halls of Infusion
     [375349] = 20, -- Gusting Breath (Gusting Proto-Drake)


### PR DESCRIPTION
- RLP: Stone Missile (Primal Terrasentry) removed
- NELT: Erupted Ground (Chargath) avoidable now by knockback?, Fiery Focus (Chargath) no longer AoE
- NO: Multi-Shot (Nokhud Longbow) removed, Rotting Wind (Desecrated Ohuna) new version no longer avoidable
- BH: Stink Breath (Stinkbreath) does no longer follow
- AV: Erupting Fissure (Leymor) no longer avoidable for tanks
- HOI: Thunderstorm (Primalist Galesinger) removed
- AA: Arcane Rain (Spellbound Scepter) removed
- archive rotating dungeons and close cleared issue [Close #54]