### PR TITLE
Fixes

### DIFF
--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -134,14 +134,12 @@ local Spells = {
     [431494] = 20, -- Black Edge (Nightfall Tactician)
     [432606] = 20, -- Black Hail (Manifested Shadow)
     [451098] = 20, -- Tacky Nova (Sureki Militant)
-    [451115] = 20, -- Terrifying Slam, Area (Ixkreten the Unbreakable)
     [460135] = 20, -- Dark Scars (Deathscreamer Iken'tak)
     [431352] = 20, -- Tormenting Eruption, Splash (Nightfall Dark Architect)
 
     [453214] = 20, -- Obsidian Beam, Beams (Speaker Shadowcrown)
     [453173] = 20, -- Collapsing Night, Area (Speaker Shadowcrown)
     [451032] = 20, -- Darkness Comes (Speaker Shadowcrown)
-    [427007] = 20, -- Terrifying Slam, Area (Anub'ikkaj)
     [427378] = 20, -- Dark Scars (Anub'ikkaj)
     [434655] = 20, -- Arathi Bomb, Explosion (Rasha'nan)
     [448215] = 20, -- Expel Webs (Rasha'nan)
@@ -192,7 +190,7 @@ local Spells = {
     [438825] = 20, -- Poisonous Cloud, Area (Atik)
     [453160] = 20, -- Impale (Hulking Bloodguard)
     [433843] = 20, -- Erupting Webs (Blood Overseer)
-    [432031] = 20, -- Grasping Blood (Black Blood) - TODO necessary for Ki'katal Cosmic Singularity?
+    --[432031] = 20, -- Grasping Blood (Black Blood) - necessary for Ki'katal Cosmic Singularity
 
     [438966] = 20, -- Gossamer Onslaught, Swirly (Avanoxx)
     [433443] = 20, -- Impale (Anub'zekt)
@@ -272,7 +270,7 @@ local Spells = {
     [272546] = 20, -- Banana Rampage (Bilge Rat Buccaneer)
     [277535] = 20, -- Viq'Goth's Wrath (Environment)
 
-    [273681] = 20, -- Heavy Hitter (Chopper Redhook) - is this reasonable?
+    [273681] = 20, -- Heavy Hitter (Chopper Redhook)
     [257585] = 20, -- Cannon Barrage (Chopper Redhook)
     [273716] = 20, -- Heavy Ordnance, Impact (Chopper Redhook)
     [273718] = 20, -- Heavy Ordnance, Explosion (Chopper Redhook) - is this reasonable?
@@ -331,6 +329,10 @@ local SpellsNoTank = {
     -- Priory of the Sacred Flame
     [444705] = 20, -- Divine Storm (Zealous Templar) - potentially still unreasonable
 
+	-- The Dawnbreaker
+	[451115] = 20, -- Terrifying Slam, Area (Ixkreten the Unbreakable)
+	[427007] = 20, -- Terrifying Slam, Area (Anub'ikkaj)
+
     -- City of Threads
     [439764] = 20, -- Process of Elimination, Physical (Izo the Grand Splicer)
     [439763] = 20, -- Process of Elimination, Shadow (Izo the Grand Splicer)
@@ -341,7 +343,7 @@ local SpellsNoTank = {
     [323489] = 20, -- Throw Cleaver (Flesh Crafter / Stitching Assistant)
 
     -- Siege of Boralus
-    [273720] = 20, -- Heavy Ordnance, Contact (Chopper Redhook) - is this reasonable?
+    --[273720] = 20, -- Heavy Ordnance, Contact (Chopper Redhook) - is this reasonable?
 }
 
 local Auras = {


### PR DESCRIPTION
- The Dawnbreaker: Terrifying Slam Area always hits tank, but does not fear
- Ara-Kara: Grasping Blood is necessary for most specs to avoid Ki'katal's Cosmic Singularity cast
- Siege of Boralus: removed Heavy Ordnance Contact (it is always better to trigger it yourself instead of letting it blow up)



- Ara-Kara: I am still not entirely sure if Burrow Charge from Anub'zekt is always avoidable. Is this something that players just need to learn the timing of or is it basically unavoidable without a strong movement cd? I have gotten very mixed results and will require more testing.