### PR TITLE
The War Within Season 2

### DIFF
--- a/Spells/DungeonArchive/3-Cataclysm
+++ b/Spells/DungeonArchive/3-Cataclysm
@@ -19,7 +19,7 @@ local Spells = {
     [428809] = 20, -- Gushing Ink (Sludge, Ozumat)
 
 
-    -- Vortex Pinnacle
+    -- The Vortex Pinnacle
     [410999] = 20, -- Pressurized Blast (Armored Mistral)
     -- [411001] = 20, -- Lethal Current (Lurking Tempest) - should this be considered avoidable?
     [411005] = 20, -- Bomb Cyclone (Cloud Prince)
@@ -34,6 +34,29 @@ local Spells = {
     [413275] = 20, -- Cold Front (Environment, Altairus)
     [87553] = 20, -- Supremacy of the Storm (Asaad)
     [87618] = 20 -- Static Cling (Asaad)
+
+
+    -- Grim Batol
+    [456701] = 20, -- Obsidian Stomp (Twilight Brute)
+    [451614] = 20, -- Twilight Ember (Twilight Destroyer)
+    [454216] = 20, -- Boiling Lava (Environment)
+    [462219] = 20, -- Blazing Shadowflame, Frontal (Twilight Flamerender)
+    [462220] = 20, -- Blazing Shadowflame, Area (Twilight Flamerender)
+    [456711] = 20, -- Shadowlava Blast (Twilight Lavabender)
+    [451389] = 20, -- Ascension, Swirly (Twilight Lavabender)
+    [451394] = 20, -- Mind Piercer (Faceless Corruptor)
+
+    [448566] = 20, -- Shadowflame Breath (Twilight Drake, General Umbriss)
+    [448953] = 20, -- Rumbling Earth (General Umbriss)
+    [449536] = 20, -- Molten Pool (Forgemaster Throngus)
+    [447395] = 20, -- Fiery Cleave (Forgemaster Throngus)
+    [448028] = 20, -- Invocation of Shadowflame, Swirly (Drahga Shadowburner)
+    [75238] = 20, -- Shadowflame Nova (Invoked Shadowflame Spirit, Drahga Shadowburner) - is this reasonable?
+    [448105] = 20, -- Devouring Flame (Valiona, Drahga Shadowburner)
+    [456773] = 20, -- Twilight Wind (Valiona, Drahga Shadowburner)
+    [450087] = 20, -- Depth's Grasp (Void Tendril, Erudax)
+    [461513] = 20, -- Shadow Gale, shrinking (Erudax)
+    [449985] = 20, -- Shadow Gale, formed (Erudax)
 }
 
 

--- a/Spells/DungeonArchive/7-Battle_for_Azeroth
+++ b/Spells/DungeonArchive/7-Battle_for_Azeroth
@@ -76,6 +76,39 @@ local Spells = {
     [257315] = 20, -- Black Powder Bomb (Irontide Grenadier, Harlan Sweete)
 
 
+    -- Siege of Boralus
+    [256627] = 20, -- Slobber Knocker (Scrimshaw Enforcer)
+    [275775] = 20, -- Savage Tempest (Irontide Raider)
+    [257069] = 20, -- Watertight Shell, Explosion (Irontide Waveshaper)
+    [256660] = 20, -- Burning Tar, Impact (Blacktar Bomber)
+    [256663] = 20, -- Burning Tar, Area (Blacktar Bomber)
+    [272140] = 20, -- Iron Volley (Irontide Powdershot, Gauntlet)
+    [272426] = 20, -- Sighted Artillery (Ashvane Spotter / Dread Captain Lockwood)
+    [280679] = 20, -- Cannon Barrage (Environment)
+    [268260] = 20, -- Broadside (Ashvane Canoneer)
+    [277432] = 20, -- Iron Volley (Ashvane Sniper, Gauntlet)
+    [272546] = 20, -- Banana Rampage (Bilge Rat Buccaneer)
+    [277535] = 20, -- Viq'Goth's Wrath (Environment)
+
+    [273681] = 20, -- Heavy Hitter (Chopper Redhook)
+    [257585] = 20, -- Cannon Barrage (Chopper Redhook)
+    [273716] = 20, -- Heavy Ordnance, Impact (Chopper Redhook)
+    [273718] = 20, -- Heavy Ordnance, Explosion (Chopper Redhook) - is this reasonable?
+    --[257326] = 20, -- Gore Crash (Chopper Redhook) - always does damage to party as well
+    [257292] = 20, -- Heavy Slash (Irontide Cleaver, Chopper Redhook)
+    [269029] = 20, -- Clear the Deck (Dread Captain Lockwood)
+    [268443] = 20, -- Dread Volley (Dread Captain Lockwood)
+    [261565] = 20, -- Crashing Tide (Hadal Darkfathom)
+    [257886] = 20, -- Brine Pool (Hadal Darkfathom)
+    --[257883] = 20, -- Break Water (Hadal Darkfathom) - always does damage to party as well
+    [276042] = 20, -- Tidal Surge (Hadal Darkfathom)
+    [270187] = 20, -- Call of the Deep (Viq'Goth)
+    [270484] = 20, -- Call of the Deep (Viq'Goth)
+    [275051] = 20, -- Putrid Waters, Dispel (Viq'Goth)
+    [280485] = 20, -- Terror from Below / Crushing Embrace (Viq'Goth)
+    [269484] = 20, -- Eradication (Viq'Goth)
+
+
     -- Waycrest Manor
     [265372] = 20, -- Shadow Cleave (Enthralled Guard)
     -- [278849] = 20, -- Uproot (Coven Thornshaper) - TODO probably not avoidable
@@ -157,6 +190,9 @@ local SpellsNoTank = {
     [260793] = 20, -- Indigestion (Cragmaw the Infested)
     [272457] = 20, -- Shockwave (Sporecaller Zancha)
 
+    -- Siege of Boralus
+    --[273720] = 20, -- Heavy Ordnance, Contact (Chopper Redhook) - is this reasonable?
+
     -- Operation: Mechagon - Workshop
     [294291] = 20, -- Process Waste (Waste Processing Unit)
 }
@@ -170,6 +206,10 @@ local Auras = {
     -- Freehold
     [274516] = true, -- Slippery Suds (Bilge Rat Swabby)
     [272554] = true -- Bloody Mess (Trothak, Ring of Booty)
+
+    -- Siege of Boralus
+    [257169] = true, -- Terrifying Roar (Bilge Rat Demolisher)
+    [274942] = true, -- Banana Rampage (Bilge Rat Buccaneer)
 
     -- Waycrest Manor
     [265352] = true, -- Toad Blight (Blight Toad)

--- a/Spells/DungeonArchive/8-Shadowlands
+++ b/Spells/DungeonArchive/8-Shadowlands
@@ -13,30 +13,32 @@ local Spells = {
 
 
     -- The Necrotic Wake
-    [324391] = 20, -- Frigid Spikes (Skeletal Monstrosity)
-    [324381] = 20, -- Chill Scythe / Reaping Winds (Skeletal Monstrosity)
-    [323957] = 20, -- Animate Dead (Zolramus Necromancer - summons Warrior)
-    [324026] = 20, -- Animate Dead (Zolramus Necromancer - summons Crossbowman)
-    [324027] = 20, -- Animate Dead (Zolramus Necromancer - summons Mage)
+    [323957] = 20, -- Animate Dead, Warrior (Zolramus Necromancer)
+    [324026] = 20, -- Animate Dead, Crossbowman (Zolramus Necromancer)
+    [324027] = 20, -- Animate Dead, Mage (Zolramus Necromancer)
     [320574] = 20, -- Shadow Well (Zolramus Sorcerer)
-    [333477] = 20, -- Gut Slice (Goregrind)
     [345625] = 20, -- Death Burst (Nar'zudah)
+    [324391] = 20, -- Frigid Spikes (Skeletal Monstrosity)
+    [324381] = 20, -- Reaping Winds / Chill Scythe (Skeletal Monstrosity)
     [327240] = 20, -- Spine Crush (Loyal Creation)
+    [333477] = 20, -- Gut Slice (Goregrind)
 
     [320646] = 20, -- Fetid Gas (Blightbone)
-    [319897] = 20, -- Land of the Dead (Amarth - summons Crossbowman)
-    [319902] = 20, -- Land of the Dead (Amarth - summons Warrior)
-    [333627] = 20, -- Land of the Dead (Amarth - summons Mage)
-    [321253] = 20, -- Final Harvest (Amarth)
+    [319897] = 20, -- Land of the Dead, Crossbowman (Amarth)
+    [319902] = 20, -- Land of the Dead, Warrior (Amarth)
+    [333627] = 20, -- Land of the Dead, Mage (Amarth)
+    [321253] = 20, -- Final Harvest, Swirly (Amarth)
     [333489] = 20, -- Necrotic Breath (Amarth)
     [333492] = 20, -- Necrotic Ichor (Amarth)
-    [320365] = 20, -- Embalming Ichor (Surgeon Stitchflesh)
-    [320366] = 20, -- Embalming Ichor (Surgeon Stitchflesh)
-    [327952] = 20, -- Meat Hook (Surgeon Stitchflesh - Stitchflesh's Creation)
-    [327100] = 20, -- Noxious Fog (Surgeon Stitchflesh)
-    [328212] = 20, -- Razorshard Ice (Nalthor the Rimebinder)
+    [320365] = 20, -- Embalming Ichor, Swirly (Surgeon Stitchflesh)
+    [320366] = 20, -- Embalming Ichor, Area (Surgeon Stitchflesh)
+    [327952] = 20, -- Meat Hook (Stitchflesh's Creation, Surgeon Stitchflesh)
+    [327100] = 20, -- Noxious Fog (Environment, Surgeon Stitchflesh)
     [320784] = 20, -- Comet Storm (Nalthor the Rimebinder)
-    [321956] = 20, -- Comet Storm (Nalthor the Rimebinder - Dark Exile Version)
+    [321956] = 20, -- Comet Storm, Dark Exile (Nalthor the Rimebinder)
+    [322793] = 20, -- Blizzard, Dark Exile (Nalthor the Rimebinder)
+    [327875] = 20, -- Blizzard, Dark Exile (Nalthor the Rimebinder)
+    [328212] = 20, -- Razorshard Ice (Nalthor the Rimebinder)
 
 
     -- Spires of Ascension
@@ -112,24 +114,26 @@ local Spells = {
 
     -- Mists of Tirna Scithe
     [321968] = 20, -- Bewildering Pollen (Tirnenn Villager)
-    [323137] = 20, -- Bewildering Pollen (Tirnenn Villager)
     [325027] = 20, -- Bramble Burst (Drust Boughbreaker)
-    [326022] = 20, -- Acid Globule (Spinemaw Gorger)
+    [463257] = 20, -- Mist Ward (Mistveil Defender)
     [340300] = 20, -- Tongue Lashing (Mistveil Gorgegullet)
     [340304] = 20, -- Poisonous Secretions (Mistveil Gorgegullet)
     [340311] = 20, -- Crushing Leap (Mistveil Gorgegullet)
-    [331743] = 20, -- Bucking Rampage (Mistveil Guardian)
-    [331748] = 20, -- Back Kick (Mistveil Guardian)
     [340160] = 20, -- Radiant Breath (Mistveil Matriarch)
+    [340283] = 20, -- Poisonous Discharge (Mistveil Nightblossom)
+    [326022] = 20, -- Acid Globule (Spinemaw Gorger)
+    [326017] = 20, -- Decomposing Acid (Spinemaw Larva)
 
-    [323263] = 20, -- Tears of the Forest (Ingra Maloch)
-    [323250] = 20, -- Anima Puddle (Droman Oulfarran)
+    [323263] = 20, -- Tears of the Forest (Droman Oulfarran, Ingra Maloch)
+    [323250] = 20, -- Anima Puddle (Droman Oulfarran, Ingra Maloch)
+    [323137] = 20, -- Bewildering Pollen (Droman Oulfarran, Ingra Maloch)
     [321834] = 20, -- Dodge Ball (Mistcaller)
     [336759] = 20, -- Dodge Ball (Mistcaller)
     [321893] = 20, -- Freezing Burst (Mistcaller)
     [321828] = 20, -- Patty Cake (Mistcaller)
     [322655] = 20, -- Acid Expulsion (Tred'ova)
     [326309] = 20, -- Decomposing Acid (Tred'ova)
+    [463603] = 20, -- Coalescing Poison (Tred'ova)
     [326263] = 20, -- Anima Shedding (Tred'ova)
 
 
@@ -247,9 +251,6 @@ local SpellsNoTank = {
     [317943] = 20, -- Sweeping Blow (Frostsworn Vanguard)
     [324608] = 20, -- Charged Stomp (Oryphrion)
 
-    -- Mists of Tirna Scithe
-    [331721] = 20, -- Spear Flurry (Mistveil Defender)
-
     -- De Other Side
     [332157] = 20, -- Spinning Up (Headless Client)
 
@@ -270,6 +271,9 @@ local Auras = {
 
     -- Spires of Ascension
     [324205] = true, -- Blinding Flash (Ventunax)
+
+    -- Mists of Tirna Scithe
+    [322968] = true, -- Dying Breath (Drust Spiteclaw)
 
     -- De Other Side
     [331381] = true, -- Slipped (Lubricator)

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -199,31 +199,36 @@ local Spells = {
 
 
     -- Theater of Pain
-    [342126] = 20, -- Brutal Leap (Dokigg the Brutalizer)
+    [317605] = 20, -- Whirlwind (Dokigg the Brutalizer / Nekthara the Mangler / Rek the Hardened)
+    [1213695] = 20, -- Earthcrusher, Swirlies (Dokigg the Brutalizer)
     [337037] = 20, -- Whirling Blade (Nekthara the Mangler)
-    [317605] = 20, -- Whirlwind (Nekthara the Mangler / Rek the Hardened)
     [332708] = 20, -- Ground Smash (Heavin the Breaker)
     [334025] = 20, -- Bloodthirsty Charge (Haruga the Bloodthirsty)
+    [317367] = 20, -- Necrotic Volley (Environment)
     [333301] = 20, -- Curse of Desolation (Nefarious Darkspeaker)
     [333297] = 20, -- Death Winds (Nefarious Darkspeaker)
     [331243] = 20, -- Bone Spikes (Soulforged Bonereaver)
     [331224] = 20, -- Bonestorm (Soulforged Bonereaver)
-    [330592] = 20, -- Vile Eruption (Rancid Gasbag - back)
-    [330608] = 20, -- Vile Eruption (Rancid Gasbag - front)
-    [321039] = 20, -- Disgusting Burst (Disgusting Refuse / Blighted Sludge-Spewer)
     [321041] = 20, -- Disgusting Burst (Disgusting Refuse / Blighted Sludge-Spewer)
+    [330592] = 20, -- Vile Eruption (Rancid Gasbag)
+    [330608] = 20, -- Vile Eruption (Rancid Gasbag)
+    [342103] = 20, -- Rancid Bile (Rancid Gasbag)
 
+    [1215738] = 20, -- Decaying Breath (Paceran the Virulent, An Affront of Challengers)
+    [1215636] = 20, -- Necrotic Spores, Swirlies (Paceran the Virulent, An Affront of Challengers)
+    [320180] = 20, -- Necrotic Spores, Area (Paceran the Virulent, An Affront of Challengers)
     [317231] = 20, -- Crushing Slam (Xav the Unfallen)
     [339415] = 20, -- Deafening Crash (Xav the Unfallen)
     [320729] = 20, -- Massive Cleave (Xav the Unfallen)
+    [473519] = 20, -- Death Spiral, Orb (Kul'tharok)
+    [1223240] = 20, -- Death Spiral, Area (Kul'tharok)
     [318406] = 20, -- Tenderizing Smash (Gorechop)
     [323406] = 20, -- Jagged Gash (Gorechop)
-    [323130] = 20, -- Coagulating Ooze (Gorechop)
-    [317367] = 20, -- Necrotic Volley (Kul'tharok)
-    [319639] = 20, -- Grasping Hands (Kul'tharok)
+    [323750] = 20, -- Vile Gas (Gorechop)
+    [323130] = 20, -- Coagulating Ooze (Oozing Leftover, Gorechop)
     [323681] = 20, -- Dark Devastation (Mordretha)
-    [339550] = 20, -- Echo of Battle (Mordretha)
     [323831] = 20, -- Death Grasp (Mordretha)
+    [339550] = 20, -- Echo of Battle (Mordretha)
     [339751] = 20, -- Ghostly Charge (Mordretha)
 
 
@@ -276,6 +281,9 @@ local SpellsNoTank = {
     [439764] = 20, -- Process of Elimination, Physical (Izo the Grand Splicer)
     [439763] = 20, -- Process of Elimination, Shadow (Izo the Grand Splicer)
     [450055] = 20, -- Gutburst (Ravenous Scarab, Izo the Grand Splicer) - is this reasonable?
+
+    -- Theater of Pain
+    [474084] = 20, -- Necrotic Eruption (Kul'tharok)
 
     -- Operation: Mechagon - Workshop
     [294291] = 20, -- Process Waste (Waste Processing Unit)

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -233,6 +233,31 @@ local Spells = {
 
 
     -- The MOTHERLODE!!
+    [257371] = 20, -- Tear Gas, Swirly (Mechanized Peacekeeper)
+    [1217283] = 20, -- Tear Gas, Area (Mechanized Peacekeeper)
+    [269831] = 20, -- Toxic Sludge (Environment)
+    [473198] = 20, -- Azerite Eruption (Azerite Extractor)
+    [269313] = 20, -- Final Blast (Wanton Sapper)
+    [268365] = 20, -- Mining Charge (Wanton Sapper)
+    [1214754] = 20, -- Massive Slam (Taskmaster Askari)
+    [271583] = 20, -- Black Powder Special (Environment)
+    [1215424] = 20, -- Brainstorm, Swirly (Venture Co. Mastermind)
+    [1214748] = 20, -- Brainstorm, Tornado (Venture Co. Mastermind)
+    [271432] = 20, -- Test Missile (Environment)
+    [262348] = 20, -- Mine Blast (Crawler Mine)
+    [269092] = 20, -- Artillery Barrage (Ordnance Specialist)
+
+    [1217286] = 20, -- Throw Coins (Footbomb Hooligan, Coin-Operated Crowd Pummeler)
+    [256137] = 20, -- Timed Detonation (Coin-Operated Crowd Pummeler)
+    [1217296] = 20, -- Shocking Claw (Coin-Operated Crowd Pummeler)
+    [275907] = 20, -- Tectonic Smash (Azerokk)
+    [258628] = 20, -- Resonant Quake, Area (Azerokk)
+    [1214673] = 20, -- Azerite Aftershock (Azerokk) - TODO is this reasonable?
+    [259533] = 20, -- Azerite Catalyst (Rixxa Fluxflame)
+    [260279] = 20, -- Gatling Gun (Mogul Razdunk)
+    [276234] = 20, -- Micro Missiles (B.O.O.M.B.A., Mogul Razdunk)
+    [270277] = 20, -- Big Red Rocket (Mogul Razdunk)
+    [270926] = 20, -- Drill Smash, Swirly (Mogul Razdunk)
 
 
     -- Operation: Mechagon - Workshop
@@ -240,9 +265,11 @@ local Spells = {
     [282945] = 20, -- Buzz Saw (Environment)
     [294128] = 20, -- Rocket Barrage (Rocket Tonk)
     [301299] = 20, -- Furnace Flames (Environment)
+    [294549] = 20, -- Furnace Flames (Environment)
     [293861] = 20, -- Anti-Personnel Squirrel (Anti-Personnel Squirrel)
     [295168] = 20, -- Capacitor Discharge (Blastatron X-80)
     [293986] = 20, -- Sonic Pulse (Spider Tank / Blastatron X-80)
+    [1213154] = 20, -- Electrified Floor (Environment)
 
     [1215039] = 20, -- B.4.T.T.L.3. Mine, Swirly (Gnomercy 4.U., Tussle Tonks)
     [285377] = 20, -- B.4.T.T.L.3. Mine, Mine (Gnomercy 4.U., Tussle Tonks)
@@ -281,6 +308,10 @@ local SpellsNoTank = {
 
     -- Theater of Pain
     [474084] = 20, -- Necrotic Eruption (Kul'tharok)
+
+    -- The MOTHERLODE!!
+    [258674] = 20, -- Throw Wrench (Off-Duty Laborer) - TODO is this reasonable?
+    [257544] = 20, -- Jagged Cut (Earthrager, Azerokk) - TODO is this reasonable?
 
     -- Operation: Mechagon - Workshop
     [1215065] = 20, -- Platinum Pummel (The Platinum Pummeler, Tussle Tonks)

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -239,28 +239,25 @@ local Spells = {
     [282943] = 20, -- Piston Smasher (Environment)
     [282945] = 20, -- Buzz Saw (Environment)
     [294128] = 20, -- Rocket Barrage (Rocket Tonk)
-    [294073] = 20, -- Flying Peck (Strider Tonk)
-    [294349] = 20, -- Volatile Waste (Living Waste)
     [301299] = 20, -- Furnace Flames (Environment)
     [293861] = 20, -- Anti-Personnel Squirrel (Anti-Personnel Squirrel)
-    [294324] = 20, -- Mega Drill (Waste Processing Unit)
     [295168] = 20, -- Capacitor Discharge (Blastatron X-80)
     [293986] = 20, -- Sonic Pulse (Spider Tank / Blastatron X-80)
-    [294058] = 20, -- High-Explosive Rockets (Spider Tank / Blastatron X-80)
 
-    [285020] = 20, -- Whirling Edge (The Platinum Pummeler)
-    [285377] = 20, -- B.4.T.T.L.3. Mine (The Platinum Pummeler)
-    [283422] = 20, -- Maximum Thrust (Gnomercy 4.U.)
+    [1215039] = 20, -- B.4.T.T.L.3. Mine, Swirly (Gnomercy 4.U., Tussle Tonks)
+    [285377] = 20, -- B.4.T.T.L.3. Mine, Mine (Gnomercy 4.U., Tussle Tonks)
+    [283422] = 20, -- Maximum Thrust (Gnomercy 4.U., Tussle Tonks)
     [291930] = 20, -- Air Drop (K.U-J.0.)
     [291953] = 20, -- Junk Bomb (K.U.-J.0.)
     [291949] = 20, -- Venting Flames (K.U-J.0.)
-    [294954] = 20, -- Self-Trimming Hedge (Machinist's Garden)
-    [285443] = 20, -- "Hidden" Flame Cannon (Machinist's Garden)
-    [285460] = 20, -- Discom-BOMB-ulator (Machinist's Garden)
-    [294869] = 20, -- Roaring Flame (Machinist's Garden)
-    [291613] = 20, -- Take Off! (King Mechagon)
+    [294954] = 20, -- Self-Trimming Hedge (Head Machinist Sparkflux, Machinist's Garden)
+    [285443] = 20, -- "Hidden" Flame Cannon (Head Machinist Sparkflux, Machinist's Garden)
+    [285460] = 20, -- Discom-BOMB-ulator (Head Machinist Sparkflux, Machinist's Garden)
+    [294869] = 20, -- Roaring Flame (Inconspicuous Plant, Machinist's Garden)
     [291915] = 20, -- Plasma Orb (King Mechagon)
     [291856] = 20, -- Recalibrate (King Mechagon)
+    [291613] = 20, -- Take Off! (Aerial Unit R-21/X, King Mechagon)
+    [291914] = 20, -- Cutting Beam, Beam (Aerial Unit R-21/X, King Mechagon)
 }
 
 
@@ -286,7 +283,7 @@ local SpellsNoTank = {
     [474084] = 20, -- Necrotic Eruption (Kul'tharok)
 
     -- Operation: Mechagon - Workshop
-    [294291] = 20, -- Process Waste (Waste Processing Unit)
+    [1215065] = 20, -- Platinum Pummel (The Platinum Pummeler, Tussle Tonks)
 }
 
 local Auras = {
@@ -301,7 +298,7 @@ local Auras = {
     [436614] = true, -- Web Wrap (Environment / Ixin / Nakt / Atik / Avanoxx)
 
     -- Operation: Mechagon - Workshop
-    [285153] = true, -- Foe Flipper (Gnomercy 4.U.)
+    [295130] = true, -- Neutralize Threat (Detect-o-bot)
 }
 
 local AurasNoTank = {}

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -82,7 +82,7 @@ local Spells = {
     [440652] = 20, -- Surging Flame, Impact (Wandering Candle)
     [440653] = 20, -- Surging Flame, Area (Wandering Candle)
     [428650] = 20, -- Burning Backlash (Environment)
-    [426265] = 20, -- Ceaseless Flame (Sootsnout) - TODO is this reasonable?
+    --[426265] = 20, -- Ceaseless Flame (Sootsnout) - TODO is this reasonable?
     [1218133] = 20, -- Burning Candles (Sootsnout)
     [422393] = 20, -- Suffocating Darkness (Skittering Darkness)
 
@@ -105,7 +105,6 @@ local Spells = {
     [427472] = 20, -- Flamestrike, Swirly (Fanatical Conjuror)
     [427473] = 20, -- Flamestrike, Area (Fanatical Conjuror)
     [427601] = 20, -- Burst of Light (Lightspawn)
-    --[448492] = 20, -- Thunderclap (Guard Captain Suleyman) - unreasonable
     [427900] = 20, -- Molten Pool (Forge Master Damian)
     [424430] = 20, -- Consecration (Ardent Paladin)
 
@@ -115,12 +114,10 @@ local Spells = {
     [423076] = 20, -- Hammer of Purity, Swirly (Baron Braunpyke)
     [423121] = 20, -- Hammer of Purity, Hammer (Baron Braunpyke)
     [423019] = 20, -- Castigator's Detonation (Baron Braunpyke)
-    --[xxxx] = 20, -- Sacrificial Pyre (Baron Braunpyke) - check Mythic-only mechanic
     [451606] = 20, -- Holy Flame (Prioress Murrpray)
     [425554] = 20, -- Purify (Prioress Murrpray)
     [425556] = 20, -- Sanctified Ground (Prioress Murrpray)
     [428170] = 20, -- Blinding Light, Disorient (Prioress Murrpray)
-    [425556] = 20, -- Sanctified Ground (Prioress Murrpray)
 
 
     -- The Dawnbreaker
@@ -264,14 +261,12 @@ local Spells = {
 
 local SpellsNoTank = {
     -- The Rookery
+    [472549] = 20, -- Volatile Void (Consuming Voidstone)
     [445537] = 20, -- Oblivion Wave (Voidstone Monstrosity)
 
     -- Cinderbrew Meadery
     [440138] = 20, -- Honey Marinade, Explosion (Benk Buzzbee)
     [436592] = 20, -- Cash Cannon (Goldie Baronbottom)
-
-    -- Priory of the Sacred Flame
-    [444705] = 20, -- Divine Storm (Zealous Templar) - potentially still unreasonable
 
 	-- The Dawnbreaker
 	[451115] = 20, -- Terrifying Slam, Area (Ixkreten the Unbreakable)
@@ -288,6 +283,7 @@ local SpellsNoTank = {
 
 local Auras = {
     -- Darkflame Cleft
+    --[426277] = true, -- One-Hand Headlock (Sootsnout) - TODO is this avoidable?
     [421653] = true, -- Cursed Wax (The Candle King)
 
     -- The Dawnbreaker

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -196,6 +196,39 @@ local Spells = {
 
 
     -- Operation: Floodgate
+    [464294] = 20, -- Weapons Stockpile Explosion (Environment)
+    [465682] = 20, -- Surprise Inspection (Darkfuse Inspector)
+    [465128] = 20, -- Wind Up (Loaderbot)
+    [461793] = 20, -- R.P.G.G. (Darkfuse Demolitionist)
+    [1215071] = 20, -- Electrified Water (Environment)
+    [472338] = 20, -- Surveyed Ground (Venture Co. Surveyor)
+    [474350] = 20, -- Shreddation Sawblade (Shreddinator 3000)
+    [474388] = 20, -- Flamethrower (Shreddinator 3000)
+    [468727] = 20, -- Seaforium Charge (Venture Co. Diver)
+    [1213790] = 20, -- Zeppelin Barrage, Swirly (Environment)
+    [1214341] = 20, -- Bomb Pile Explosion (Environment)
+    [465487] = 20, -- Bubbles Smash (Bubbles)
+    [469819] = 20, -- Bubble (Bubbles)
+    [1217496] = 20, -- Splish Splash (Bubbles)
+    [465604] = 20, -- Battery Bolt (Darkfuse Jumpstarter)
+
+    [473224] = 20, -- Sonic Boom, Wave (Big M.O.M.M.A.)
+    [473240] = 20, -- Sonic Boom, Explosion (Big M.O.M.M.A.)
+    [473287] = 20, -- Excessive Electrification (Big M.O.M.M.A.)
+    [472454] = 20, -- Doom Storm (Darkfuse Mechadrone, Big M.O.M.M.A.)
+    [473526] = 20, -- Big Bada BOOM! (Keeza Quickfuse, Demolition Duo)
+    [460787] = 20, -- Deflagration (Keeza Quickfuse, Demolition Duo) - TODO is this reasonable?
+    [472755] = 20, -- Shrapnel (Keeza Quickfuse, Demolition Duo)
+    [1217751] = 20, -- B.B.B.F.G. (Keeza Quickfuse, Demolition Duo)
+    [460965] = 20, -- Barreling Charge (Bront, Demolition Duo)
+    [473126] = 20, -- Mudslide (Swampface)
+    [473046] = 20, -- Skewering Root (Swampface)
+    [473051] = 20, -- Rushing Tide (Swampface)
+    [465982] = 20, -- Turbo Bolt (Geezle Gigazap)
+    [468604] = 20, -- Dam Rubble (Geezle Gigazap)
+    [468741] = 20, -- Shock Water, Impact (Geezle Gigazap)
+    [468723] = 20, -- Shock Water, Area (Geezle Gigazap)
+    [468647] = 20, -- Leaping Spark (Geezle Gigazap)
 
 
     -- Theater of Pain
@@ -306,6 +339,9 @@ local SpellsNoTank = {
     [439763] = 20, -- Process of Elimination, Shadow (Izo the Grand Splicer)
     [450055] = 20, -- Gutburst (Ravenous Scarab, Izo the Grand Splicer) - is this reasonable?
 
+    -- Operation: Floodgate
+    [459799] = 20, -- Wallop (Bront, Demolition Duo)
+
     -- Theater of Pain
     [474084] = 20, -- Necrotic Eruption (Kul'tharok)
 
@@ -327,6 +363,10 @@ local Auras = {
 
     -- Ara-Kara, City of Echoes
     [436614] = true, -- Web Wrap (Environment / Ixin / Nakt / Atik / Avanoxx)
+
+    -- Operation: Floodgate
+    [1215089] = true, -- Electrified Water (Environment)
+    [1213704] = true, -- Zeppelin Barrage, Spotlight (Environment)
 
     -- Operation: Mechagon - Workshop
     [295130] = true, -- Neutralize Threat (Detect-o-bot)

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -12,27 +12,24 @@ local Spells = {
     -- Affixes
 
     -- The Rookery
-    [427331] = 20, -- Charged Bombardment, Dash (Voidrider)
-    [432605] = 20, -- Charged Bombardment, Swirlies (Voidrider)
+    [474017] = 20, -- Wild Lightning (Voidrider / Kyrioss)
     [426968] = 20, -- Bounding Void (Quartermaster Koratite)
-    [430013] = 20, -- Thunderstrike (Unruly Stormrook)
+    [420679] = 20, -- Tornado Winds (Environment)
     [452932] = 20, -- Attracting Shadows, Explosion (Coalescing Void Diffuser)
-    [430186] = 20, -- Seeping Corruption (Corrupted Oracle)
-    [423981] = 20, -- Implosion, Explosion (Void Cursed Crusher)
-    [443847] = 20, -- Instability (Inflicted Civilian)
+    [430186] = 20, -- Seeping Corruption, Area (Corrupted Oracle)
+    [443847] = 20, -- Instability (Afflicted Civilian)
     [442192] = 20, -- Oppressive Void (Environment)
-    [430288] = 20, -- Crushing Darkness (Void Fragment)
-    [438848] = 20, -- Embrace the Void, Swirly (Radiating Voidstone)
+    [1214550] = 20, -- Umbral Wave (Void Ascendant)
+    [1214645] = 20, -- Erupting Darkness (Consuming Voidstone)
 
+    [444250] = 20, -- Lightning Torrent, Beams (Kyrioss)
+    [1214318] = 20, -- Grounding Bolt (Kyrioss)
     [419871] = 20, -- Lightning Dash (Kyrioss)
-    [444411] = 20, -- Stormheart (Kyrioss)
-    [444250] = 20, -- Lightning Torrent (Kyrioss)
-    [425113] = 20, -- Crush Reality (Stormguard Gorren)
-    [424966] = 20, -- Lingering Void (Stormguard Gorren)
     [426136] = 20, -- Reality Tear (Stormguard Gorren)
+    [424966] = 20, -- Lingering Void (Stormguard Gorren)
     [425052] = 20, -- Dark Gravity, Explosion (Stormguard Gorren)
     [423356] = 20, -- Null Upheaval, Swirlies (Voidstone Monstrosity)
-    --[433067] = 20, -- Seeping Fragment (Voidstone Monstrosity) - unavoidable to destroy Seeping Fragment with Stormrider's Charge
+    [433067] = 20, -- Seeping Corruption (Voidstone Monstrosity)
 
 
     -- Cinderbrew Meadery
@@ -268,8 +265,6 @@ local Spells = {
 
 local SpellsNoTank = {
     -- The Rookery
-    [427616] = 20, -- Energized Barrage (Unruly Stormrook)
-    [433078] = 20, -- Implosion, Impact (Void Cursed Crusher)
     [445537] = 20, -- Oblivion Wave (Voidstone Monstrosity)
 
     -- Cinderbrew Meadery

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -50,8 +50,8 @@ local Spells = {
     [440087] = 20, -- Oozing Honey (Brew Drop, I'pa)
     [438651] = 20, -- Snack Time (Benk Buzzbee)
     [440141] = 20, -- Honey Marinade, Area (Benk Buzzbee)
-    [438933] = 20, -- Sticky Situation (Benk Buzzbee)
-    [438931] = 20, -- Sticky Situation (Benk Buzzbee)
+    [438933] = 20, -- Sticky Situation (Benk Buzzbee) - TODO check
+    [438931] = 20, -- Sticky Situation (Benk Buzzbee) - TODO check
     [435788] = 20, -- Cinder-BOOM!, Waves (Goldie Baronbottom)
 
 

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -79,26 +79,25 @@ local Spells = {
     -- Darkflame Cleft
     [423501] = 20, -- Wild Wallop (Rank Overseer)
     [426883] = 20, -- Bonk! (Kobold Taskworker)
-    [426779] = 20, -- Explosive Flame (Blazing Fiend)
-    [440652] = 20, -- Surging Wax, Impact (Wandering Candle)
-    [440653] = 20, -- Surging Wax, Area (Wandering Candle)
+    [440652] = 20, -- Surging Flame, Impact (Wandering Candle)
+    [440653] = 20, -- Surging Flame, Area (Wandering Candle)
     [428650] = 20, -- Burning Backlash (Environment)
-    [426265] = 20, -- Ceaseless Flame (Sootsnout) - TODO always towards One-Hand Headlock stunned player?
-    [426259] = 20, -- Pyro-Pummel (Torchsnarl)
+    [426265] = 20, -- Ceaseless Flame (Sootsnout) - TODO is this reasonable?
+    [1218133] = 20, -- Burning Candles (Sootsnout)
     [422393] = 20, -- Suffocating Darkness (Skittering Darkness)
-    [422414] = 20, -- Shadow Smash (Shuffling Horror)
 
     [422125] = 20, -- Reckless Charge (Ol' Waxbeard)
     [422274] = 20, -- Cave-In (Ol' Waxbeard)
     [424821] = 20, -- High Speed Collision (Ol' Waxbeard)
-    [429093] = 20, -- Underhanded Track-tics, Explosion (Ol' Waxbeard)
+    [429093] = 20, -- Underhanded Track-tics, Explosion (Ol' Waxbeard) - TODO is this reasonable?
     [421638] = 20, -- Wicklighter Barrage (Blazikon)
-    [424223] = 20, -- Incite Flames (Blazikon)
-    [422700] = 20, -- Extinguishing Gust (Blazikon)
     [443969] = 20, -- Enkindling Inferno (Blazikon)
+    [422700] = 20, -- Extinguishing Gust (Blazikon)
+    [424223] = 20, -- Incite Flames (Blazikon)
+    [421282] = 20, -- Darkflame Pickaxe (The Candle King)
     [421067] = 20, -- Molten Wax (The Candle King)
     [427100] = 20, -- Umbral Slash (The Darkness)
-    [426943] = 20, -- Rising Gloom (The Darkness) - is this reasonable?
+    [426943] = 20, -- Rising Gloom (The Darkness)
 
 
     -- Priory of the Sacred Flame
@@ -270,9 +269,6 @@ local SpellsNoTank = {
     -- Cinderbrew Meadery
     [440138] = 20, -- Honey Marinade, Explosion (Benk Buzzbee)
     [436592] = 20, -- Cash Cannon (Goldie Baronbottom)
-
-    -- Darkflame Cleft
-    [421282] = 20, -- Darkflame Pickaxe (The Candle King)
 
     -- Priory of the Sacred Flame
     [444705] = 20, -- Divine Storm (Zealous Templar) - potentially still unreasonable

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -134,14 +134,12 @@ local Spells = {
     [431494] = 20, -- Black Edge (Nightfall Tactician)
     [432606] = 20, -- Black Hail (Manifested Shadow)
     [451098] = 20, -- Tacky Nova (Sureki Militant)
-    [451115] = 20, -- Terrifying Slam, Area (Ixkreten the Unbreakable)
     [460135] = 20, -- Dark Scars (Deathscreamer Iken'tak)
     [431352] = 20, -- Tormenting Eruption, Splash (Nightfall Dark Architect)
 
     [453214] = 20, -- Obsidian Beam, Beams (Speaker Shadowcrown)
     [453173] = 20, -- Collapsing Night, Area (Speaker Shadowcrown)
     [451032] = 20, -- Darkness Comes (Speaker Shadowcrown)
-    [427007] = 20, -- Terrifying Slam, Area (Anub'ikkaj)
     [427378] = 20, -- Dark Scars (Anub'ikkaj)
     [434655] = 20, -- Arathi Bomb, Explosion (Rasha'nan)
     [448215] = 20, -- Expel Webs (Rasha'nan)
@@ -192,7 +190,7 @@ local Spells = {
     [438825] = 20, -- Poisonous Cloud, Area (Atik)
     [453160] = 20, -- Impale (Hulking Bloodguard)
     [433843] = 20, -- Erupting Webs (Blood Overseer)
-    [432031] = 20, -- Grasping Blood (Black Blood) - TODO necessary for Ki'katal Cosmic Singularity?
+    --[432031] = 20, -- Grasping Blood (Black Blood) - necessary for Ki'katal Cosmic Singularity
 
     [438966] = 20, -- Gossamer Onslaught, Swirly (Avanoxx)
     [433443] = 20, -- Impale (Anub'zekt)
@@ -272,7 +270,7 @@ local Spells = {
     [272546] = 20, -- Banana Rampage (Bilge Rat Buccaneer)
     [277535] = 20, -- Viq'Goth's Wrath (Environment)
 
-    [273681] = 20, -- Heavy Hitter (Chopper Redhook) - is this reasonable?
+    [273681] = 20, -- Heavy Hitter (Chopper Redhook)
     [257585] = 20, -- Cannon Barrage (Chopper Redhook)
     [273716] = 20, -- Heavy Ordnance, Impact (Chopper Redhook)
     [273718] = 20, -- Heavy Ordnance, Explosion (Chopper Redhook) - is this reasonable?
@@ -331,6 +329,10 @@ local SpellsNoTank = {
     -- Priory of the Sacred Flame
     [444705] = 20, -- Divine Storm (Zealous Templar) - potentially still unreasonable
 
+	-- The Dawnbreaker
+	[451115] = 20, -- Terrifying Slam, Area (Ixkreten the Unbreakable)
+	[427007] = 20, -- Terrifying Slam, Area (Anub'ikkaj)
+
     -- City of Threads
     [439764] = 20, -- Process of Elimination, Physical (Izo the Grand Splicer)
     [439763] = 20, -- Process of Elimination, Shadow (Izo the Grand Splicer)
@@ -341,7 +343,7 @@ local SpellsNoTank = {
     [323489] = 20, -- Throw Cleaver (Flesh Crafter / Stitching Assistant)
 
     -- Siege of Boralus
-    [273720] = 20, -- Heavy Ordnance, Contact (Chopper Redhook) - is this reasonable?
+    --[273720] = 20, -- Heavy Ordnance, Contact (Chopper Redhook) - is this reasonable?
 }
 
 local Auras = {

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -202,114 +202,67 @@ local Spells = {
     [432117] = 20, -- Cosmic Singularity (Ki'katal the Harvester)
 
 
-    -- The Necrotic Wake
-    [323957] = 20, -- Animate Dead, Warrior (Zolramus Necromancer)
-    [324026] = 20, -- Animate Dead, Crossbowman (Zolramus Necromancer)
-    [324027] = 20, -- Animate Dead, Mage (Zolramus Necromancer)
-    [320574] = 20, -- Shadow Well (Zolramus Sorcerer)
-    [345625] = 20, -- Death Burst (Nar'zudah)
-    [324391] = 20, -- Frigid Spikes (Skeletal Monstrosity)
-    [324381] = 20, -- Reaping Winds / Chill Scythe (Skeletal Monstrosity)
-    [327240] = 20, -- Spine Crush (Loyal Creation)
-    [333477] = 20, -- Gut Slice (Goregrind)
-
-    [320646] = 20, -- Fetid Gas (Blightbone)
-    [319897] = 20, -- Land of the Dead, Crossbowman (Amarth)
-    [319902] = 20, -- Land of the Dead, Warrior (Amarth)
-    [333627] = 20, -- Land of the Dead, Mage (Amarth)
-    [321253] = 20, -- Final Harvest, Swirly (Amarth)
-    [333489] = 20, -- Necrotic Breath (Amarth)
-    [333492] = 20, -- Necrotic Ichor (Amarth)
-    [320365] = 20, -- Embalming Ichor, Swirly (Surgeon Stitchflesh)
-    [320366] = 20, -- Embalming Ichor, Area (Surgeon Stitchflesh)
-    [327952] = 20, -- Meat Hook (Stitchflesh's Creation, Surgeon Stitchflesh)
-    [327100] = 20, -- Noxious Fog (Environment, Surgeon Stitchflesh)
-    [320784] = 20, -- Comet Storm (Nalthor the Rimebinder)
-    [321956] = 20, -- Comet Storm, Dark Exile (Nalthor the Rimebinder)
-    [322793] = 20, -- Blizzard, Dark Exile (Nalthor the Rimebinder)
-    [327875] = 20, -- Blizzard, Dark Exile (Nalthor the Rimebinder)
-    [328212] = 20, -- Razorshard Ice (Nalthor the Rimebinder)
+    -- Operation: Floodgate
 
 
-    -- Mists of Tirna Scithe
-    [321968] = 20, -- Bewildering Pollen (Tirnenn Villager)
-    [325027] = 20, -- Bramble Burst (Drust Boughbreaker)
-    [463257] = 20, -- Mist Ward (Mistveil Defender)
-    [340300] = 20, -- Tongue Lashing (Mistveil Gorgegullet)
-    [340304] = 20, -- Poisonous Secretions (Mistveil Gorgegullet)
-    [340311] = 20, -- Crushing Leap (Mistveil Gorgegullet)
-    [340160] = 20, -- Radiant Breath (Mistveil Matriarch)
-    [340283] = 20, -- Poisonous Discharge (Mistveil Nightblossom)
-    [326022] = 20, -- Acid Globule (Spinemaw Gorger)
-    [326017] = 20, -- Decomposing Acid (Spinemaw Larva)
+    -- Theater of Pain
+    [342126] = 20, -- Brutal Leap (Dokigg the Brutalizer)
+    [337037] = 20, -- Whirling Blade (Nekthara the Mangler)
+    [317605] = 20, -- Whirlwind (Nekthara the Mangler / Rek the Hardened)
+    [332708] = 20, -- Ground Smash (Heavin the Breaker)
+    [334025] = 20, -- Bloodthirsty Charge (Haruga the Bloodthirsty)
+    [333301] = 20, -- Curse of Desolation (Nefarious Darkspeaker)
+    [333297] = 20, -- Death Winds (Nefarious Darkspeaker)
+    [331243] = 20, -- Bone Spikes (Soulforged Bonereaver)
+    [331224] = 20, -- Bonestorm (Soulforged Bonereaver)
+    [330592] = 20, -- Vile Eruption (Rancid Gasbag - back)
+    [330608] = 20, -- Vile Eruption (Rancid Gasbag - front)
+    [321039] = 20, -- Disgusting Burst (Disgusting Refuse / Blighted Sludge-Spewer)
+    [321041] = 20, -- Disgusting Burst (Disgusting Refuse / Blighted Sludge-Spewer)
 
-    [323263] = 20, -- Tears of the Forest (Droman Oulfarran, Ingra Maloch)
-    [323250] = 20, -- Anima Puddle (Droman Oulfarran, Ingra Maloch)
-    [323137] = 20, -- Bewildering Pollen (Droman Oulfarran, Ingra Maloch)
-    [321834] = 20, -- Dodge Ball (Mistcaller)
-    [336759] = 20, -- Dodge Ball (Mistcaller)
-    [321893] = 20, -- Freezing Burst (Mistcaller)
-    [321828] = 20, -- Patty Cake (Mistcaller)
-    [322655] = 20, -- Acid Expulsion (Tred'ova)
-    [326309] = 20, -- Decomposing Acid (Tred'ova)
-    [463603] = 20, -- Coalescing Poison (Tred'ova)
-    [326263] = 20, -- Anima Shedding (Tred'ova)
-
-
-    -- Siege of Boralus
-    [256627] = 20, -- Slobber Knocker (Scrimshaw Enforcer)
-    [275775] = 20, -- Savage Tempest (Irontide Raider)
-    [257069] = 20, -- Watertight Shell, Explosion (Irontide Waveshaper)
-    [256660] = 20, -- Burning Tar, Impact (Blacktar Bomber)
-    [256663] = 20, -- Burning Tar, Area (Blacktar Bomber)
-    [272140] = 20, -- Iron Volley (Irontide Powdershot, Gauntlet)
-    [272426] = 20, -- Sighted Artillery (Ashvane Spotter / Dread Captain Lockwood)
-    [280679] = 20, -- Cannon Barrage (Environment)
-    [268260] = 20, -- Broadside (Ashvane Canoneer)
-    [277432] = 20, -- Iron Volley (Ashvane Sniper, Gauntlet)
-    [272546] = 20, -- Banana Rampage (Bilge Rat Buccaneer)
-    [277535] = 20, -- Viq'Goth's Wrath (Environment)
-
-    [273681] = 20, -- Heavy Hitter (Chopper Redhook)
-    [257585] = 20, -- Cannon Barrage (Chopper Redhook)
-    [273716] = 20, -- Heavy Ordnance, Impact (Chopper Redhook)
-    [273718] = 20, -- Heavy Ordnance, Explosion (Chopper Redhook) - is this reasonable?
-    --[257326] = 20, -- Gore Crash (Chopper Redhook) - always does damage to party as well
-    [257292] = 20, -- Heavy Slash (Irontide Cleaver, Chopper Redhook)
-    [269029] = 20, -- Clear the Deck (Dread Captain Lockwood)
-    [268443] = 20, -- Dread Volley (Dread Captain Lockwood)
-    [261565] = 20, -- Crashing Tide (Hadal Darkfathom)
-    [257886] = 20, -- Brine Pool (Hadal Darkfathom)
-    --[257883] = 20, -- Break Water (Hadal Darkfathom) - always does damage to party as well
-    [276042] = 20, -- Tidal Surge (Hadal Darkfathom)
-    [270187] = 20, -- Call of the Deep (Viq'Goth)
-    [270484] = 20, -- Call of the Deep (Viq'Goth)
-    [275051] = 20, -- Putrid Waters, Dispel (Viq'Goth)
-    [280485] = 20, -- Terror from Below / Crushing Embrace (Viq'Goth)
-    [269484] = 20, -- Eradication (Viq'Goth)
+    [317231] = 20, -- Crushing Slam (Xav the Unfallen)
+    [339415] = 20, -- Deafening Crash (Xav the Unfallen)
+    [320729] = 20, -- Massive Cleave (Xav the Unfallen)
+    [318406] = 20, -- Tenderizing Smash (Gorechop)
+    [323406] = 20, -- Jagged Gash (Gorechop)
+    [323130] = 20, -- Coagulating Ooze (Gorechop)
+    [317367] = 20, -- Necrotic Volley (Kul'tharok)
+    [319639] = 20, -- Grasping Hands (Kul'tharok)
+    [323681] = 20, -- Dark Devastation (Mordretha)
+    [339550] = 20, -- Echo of Battle (Mordretha)
+    [323831] = 20, -- Death Grasp (Mordretha)
+    [339751] = 20, -- Ghostly Charge (Mordretha)
 
 
-    -- Grim Batol
-    [456701] = 20, -- Obsidian Stomp (Twilight Brute)
-    [451614] = 20, -- Twilight Ember (Twilight Destroyer)
-    [454216] = 20, -- Boiling Lava (Environment)
-    [462219] = 20, -- Blazing Shadowflame, Frontal (Twilight Flamerender)
-    [462220] = 20, -- Blazing Shadowflame, Area (Twilight Flamerender)
-    [456711] = 20, -- Shadowlava Blast (Twilight Lavabender)
-    [451389] = 20, -- Ascension, Swirly (Twilight Lavabender)
-    [451394] = 20, -- Mind Piercer (Faceless Corruptor)
+    -- The MOTHERLODE!!
 
-    [448566] = 20, -- Shadowflame Breath (Twilight Drake, General Umbriss)
-    [448953] = 20, -- Rumbling Earth (General Umbriss)
-    [449536] = 20, -- Molten Pool (Forgemaster Throngus)
-    [447395] = 20, -- Fiery Cleave (Forgemaster Throngus)
-    [448028] = 20, -- Invocation of Shadowflame, Swirly (Drahga Shadowburner)
-    [75238] = 20, -- Shadowflame Nova (Invoked Shadowflame Spirit, Drahga Shadowburner) - is this reasonable?
-    [448105] = 20, -- Devouring Flame (Valiona, Drahga Shadowburner)
-    [456773] = 20, -- Twilight Wind (Valiona, Drahga Shadowburner)
-    [450087] = 20, -- Depth's Grasp (Void Tendril, Erudax)
-    [461513] = 20, -- Shadow Gale, shrinking (Erudax)
-    [449985] = 20, -- Shadow Gale, formed (Erudax)
+
+    -- Operation: Mechagon - Workshop
+    [282943] = 20, -- Piston Smasher (Environment)
+    [282945] = 20, -- Buzz Saw (Environment)
+    [294128] = 20, -- Rocket Barrage (Rocket Tonk)
+    [294073] = 20, -- Flying Peck (Strider Tonk)
+    [294349] = 20, -- Volatile Waste (Living Waste)
+    [301299] = 20, -- Furnace Flames (Environment)
+    [293861] = 20, -- Anti-Personnel Squirrel (Anti-Personnel Squirrel)
+    [294324] = 20, -- Mega Drill (Waste Processing Unit)
+    [295168] = 20, -- Capacitor Discharge (Blastatron X-80)
+    [293986] = 20, -- Sonic Pulse (Spider Tank / Blastatron X-80)
+    [294058] = 20, -- High-Explosive Rockets (Spider Tank / Blastatron X-80)
+
+    [285020] = 20, -- Whirling Edge (The Platinum Pummeler)
+    [285377] = 20, -- B.4.T.T.L.3. Mine (The Platinum Pummeler)
+    [283422] = 20, -- Maximum Thrust (Gnomercy 4.U.)
+    [291930] = 20, -- Air Drop (K.U-J.0.)
+    [291953] = 20, -- Junk Bomb (K.U.-J.0.)
+    [291949] = 20, -- Venting Flames (K.U-J.0.)
+    [294954] = 20, -- Self-Trimming Hedge (Machinist's Garden)
+    [285443] = 20, -- "Hidden" Flame Cannon (Machinist's Garden)
+    [285460] = 20, -- Discom-BOMB-ulator (Machinist's Garden)
+    [294869] = 20, -- Roaring Flame (Machinist's Garden)
+    [291613] = 20, -- Take Off! (King Mechagon)
+    [291915] = 20, -- Plasma Orb (King Mechagon)
+    [291856] = 20, -- Recalibrate (King Mechagon)
 }
 
 
@@ -338,12 +291,8 @@ local SpellsNoTank = {
     [439763] = 20, -- Process of Elimination, Shadow (Izo the Grand Splicer)
     [450055] = 20, -- Gutburst (Ravenous Scarab, Izo the Grand Splicer) - is this reasonable?
 
-    -- The Necrotic Wake
-    [324323] = 20, -- Gruesome Cleave (Skeletal Marauder)
-    [323489] = 20, -- Throw Cleaver (Flesh Crafter / Stitching Assistant)
-
-    -- Siege of Boralus
-    --[273720] = 20, -- Heavy Ordnance, Contact (Chopper Redhook) - is this reasonable?
+    -- Operation: Mechagon - Workshop
+    [294291] = 20, -- Process Waste (Waste Processing Unit)
 }
 
 local Auras = {
@@ -356,15 +305,8 @@ local Auras = {
     -- Ara-Kara, City of Echoes
     [436614] = true, -- Web Wrap (Environment / Ixin / Nakt / Atik / Avanoxx)
 
-    -- The Necrotic Wake
-    [324293] = true, -- Rasping Scream (Skeletal Marauder)
-
-    -- Mists of Tirna Scithe
-    [322968] = true, -- Dying Breath (Drust Spiteclaw)
-
-    -- Siege of Boralus
-    [257169] = true, -- Terrifying Roar (Bilge Rat Demolisher)
-    [274942] = true, -- Banana Rampage (Bilge Rat Buccaneer)
+    -- Operation: Mechagon - Workshop
+    [285153] = true, -- Foe Flipper (Gnomercy 4.U.)
 }
 
 local AurasNoTank = {}

--- a/Spells/Dungeons.lua
+++ b/Spells/Dungeons.lua
@@ -188,7 +188,7 @@ local Spells = {
     [438966] = 20, -- Gossamer Onslaught, Swirly (Avanoxx)
     [433443] = 20, -- Impale (Anub'zekt)
     [433781] = 20, -- Ceaseless Swarm (Anub'zekt)
-    [434284] = 20, -- Burrow Charge, Dash (Anub'zekt) - TODO difficult for target to avoid, impossible without dash?
+    [434284] = 20, -- Burrow Charge, Dash (Anub'zekt)
     [433731] = 20, -- Burrow Charge, End (Anub'zekt)
     [432132] = 20, -- Erupting Webs (Ki'katal the Harvester)
     [461507] = 20, -- Cultivated Poisons, Wave (Ki'katal the Harvester)
@@ -232,11 +232,11 @@ local Spells = {
 
 
     -- Theater of Pain
-    [317605] = 20, -- Whirlwind (Dokigg the Brutalizer / Nekthara the Mangler / Rek the Hardened)
-    [1213695] = 20, -- Earthcrusher, Swirlies (Dokigg the Brutalizer)
-    [337037] = 20, -- Whirling Blade (Nekthara the Mangler)
-    [332708] = 20, -- Ground Smash (Heavin the Breaker)
-    [334025] = 20, -- Bloodthirsty Charge (Haruga the Bloodthirsty)
+    [317605] = 20, -- Whirlwind (Dokigg the Brutalizer / Nekthara the Mangler / Rek the Hardened) - Champions in Halls of Might have had their abilities redistributed
+    [1213695] = 20, -- Earthcrusher, Swirlies (Dokigg the Brutalizer) - Champions in Halls of Might have had their abilities redistributed
+    [337037] = 20, -- Whirling Blade (Nekthara the Mangler) - Champions in Halls of Might have had their abilities redistributed
+    [332708] = 20, -- Ground Smash (Heavin the Breaker) - Champions in Halls of Might have had their abilities redistributed
+    [334025] = 20, -- Bloodthirsty Charge (Haruga the Bloodthirsty) - Champions in Halls of Might have had their abilities redistributed
     [317367] = 20, -- Necrotic Volley (Environment)
     [333301] = 20, -- Curse of Desolation (Nefarious Darkspeaker)
     [333297] = 20, -- Death Winds (Nefarious Darkspeaker)
@@ -337,10 +337,7 @@ local SpellsNoTank = {
     -- City of Threads
     [439764] = 20, -- Process of Elimination, Physical (Izo the Grand Splicer)
     [439763] = 20, -- Process of Elimination, Shadow (Izo the Grand Splicer)
-    [450055] = 20, -- Gutburst (Ravenous Scarab, Izo the Grand Splicer) - is this reasonable?
-
-    -- Operation: Floodgate
-    [459799] = 20, -- Wallop (Bront, Demolition Duo)
+    [450055] = 20, -- Gutburst (Ravenous Scarab, Izo the Grand Splicer)
 
     -- Theater of Pain
     [474084] = 20, -- Necrotic Eruption (Kul'tharok)


### PR DESCRIPTION
- archive S1 dungeons
- update TWW dungeons for S2
- new dungeon: Floodgate
- update returning dungeons: Theater of Pain, Motherlode, Mechagon Workshop

As always, this might still contain inaccuracies that will be corrected in the coming weeks.